### PR TITLE
docs: align compatibility stub style with pixiv-cli

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,3 +1,3 @@
-# 开发文档（兼容入口）
+# Development documentation moved
 
-权威开发流程见 [维护者开发指南](maintainers/development.md)。
+See [`docs/maintainers/development.md`](maintainers/development.md).

--- a/docs/development.zh-CN.md
+++ b/docs/development.zh-CN.md
@@ -1,3 +1,3 @@
-# 开发文档（兼容入口）
+# Development documentation moved
 
-权威开发流程见 [维护者开发指南](maintainers/development.md)。
+See [`docs/maintainers/development.md`](maintainers/development.md).

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,4 +1,4 @@
-# Go SDK（兼容入口）
+# Go SDK moved
 
-请使用 [English SDK guide](en/sdk.md) 或 [简体中文 SDK guide](zh-CN/sdk.md)。
-新链接请指向 locale 目录。
+- [English](en/sdk.md)
+- [简体中文](zh-CN/sdk.md)

--- a/docs/sdk.zh-CN.md
+++ b/docs/sdk.zh-CN.md
@@ -1,3 +1,3 @@
-# Go SDK（兼容入口）
+# Go SDK moved
 
-请使用 [简体中文 SDK guide](zh-CN/sdk.md)。新链接请指向 locale 目录。
+- [简体中文](zh-CN/sdk.md)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,4 +1,4 @@
-# CLI reference（兼容入口）
+# CLI reference moved
 
-请使用 [English CLI reference](en/cli-reference.md) 或
-[简体中文 CLI reference](zh-CN/cli-reference.md)。新链接请指向 locale 目录。
+- [English](en/cli-reference.md)
+- [简体中文](zh-CN/cli-reference.md)

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -1,3 +1,3 @@
-# CLI reference（兼容入口）
+# CLI reference moved
 
-请使用 [简体中文 CLI reference](zh-CN/cli-reference.md)。新链接请指向 locale 目录。
+- [简体中文](zh-CN/cli-reference.md)


### PR DESCRIPTION
## Summary by Sourcery

更新兼容性存根文档页面，以标明已迁移位置，并直接链接到本地化的 SDK、CLI 参考文档以及维护者开发指南。

文档：
- 修改 SDK 和 CLI 参考存根页面，将其简化为链接列表，指向英文和简体中文本地化文档。
- 更新开发文档存根，以标明已迁移位置，并链接到维护者开发指南。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update compatibility stub documentation pages to indicate relocation and link directly to localized SDK, CLI reference, and maintainer development guides.

Documentation:
- Revise SDK and CLI reference stub pages to simple link lists pointing to English and Simplified Chinese localized docs.
- Update development documentation stubs to note relocation and link to the maintainers development guide.

</details>

<!-- release-note
category: Documentation
breaking: false
summary: Align SDK and CLI reference stub pages with localized documentation links.
none_reason:
-->
