### PR TITLE
docs: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,80 @@
+name: Bug report
+description: Report a reproducible problem in the CLI or public Go SDK.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report a problem. Remove or redact passwords, JWTs, proxy credentials, private URLs, `~/.javdb-cli/auth.json` contents, and private API responses before submitting.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the observed behavior and why it is incorrect.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Provide the smallest safe sequence that reproduces the problem. Use placeholder IDs or redacted values when needed.
+      placeholder: |
+        1. Run `javdb ...`
+        2. Provide the redacted input or configuration
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Describe what you expected to happen instead.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected interface
+      description: Select every interface where you observed the problem.
+      multiple: true
+      options:
+        - CLI
+        - Public Go SDK
+        - Authentication or account management
+        - Magnets, rankings, TOP250, or user lists
+        - Release installer or self-update
+        - Operator skill (skills/javdb-cli)
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include `javdb version --json`, operating system, architecture, installation method, and any relevant proxy or authentication state. Do not include secrets.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Redacted logs or output
+      description: Paste only redacted output. Never include passwords, JWTs, authorization tokens, proxy userinfo, private URLs, or response bodies.
+      render: shell
+
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety confirmation
+      options:
+        - label: I have removed all secrets and private content from this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation and usage questions
+    url: https://github.com/FlanChanXwO/javdb-cli/discussions
+    about: Ask for usage help or discuss an idea before opening a feature request.
+  - name: Security vulnerability
+    url: https://github.com/FlanChanXwO/javdb-cli/security/advisories/new
+    about: Report suspected security issues privately. Do not disclose credentials or exploit details in a public issue.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,66 @@
+name: Feature request
+description: Propose a focused improvement to javdb-cli.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please describe the user problem first. Do not include passwords, JWTs, private URLs, or private API responses.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: Explain the concrete workflow or limitation that motivates this request.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Describe the desired CLI, SDK, or documentation behavior. Include examples when useful.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected interface
+      description: Select every interface that should expose the change.
+      multiple: true
+      options:
+        - CLI
+        - Public Go SDK
+        - Authentication or account management
+        - Magnets, rankings, TOP250, or user lists
+        - Release installer or self-update
+        - Operator skill (skills/javdb-cli)
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe existing commands, workarounds, or other designs you considered.
+
+  - type: checkboxes
+    id: compatibility
+    attributes:
+      label: Compatibility
+      options:
+        - label: This proposal may require a breaking CLI, SDK, configuration, or output-contract change.
+          required: false
+
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety confirmation
+      options:
+        - label: I have not included secrets or private content in this request.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- Describe the user problem and the change that addresses it. Link related issues with "Fixes #123" when applicable. -->
+
+## Scope and compatibility
+
+<!-- List affected CLI commands or flags, public Go SDK APIs, configuration, environment variables, output contracts, agent skill files, and release behavior. State "None" when there is no public impact. -->
+
+## Verification
+
+<!-- List the exact commands you ran and their results. For real JavDB App API coverage, state whether it was run and use only redacted evidence. -->
+
+```text
+go test ./...
+sh scripts/build.sh
+```
+
+## Checklist
+
+- [ ] The change is focused and linked to an issue when appropriate.
+- [ ] I added or updated focused tests for changed behavior.
+- [ ] I ran the relevant tests and recorded the results above.
+- [ ] I updated the required CLI reference, SDK, README, maintainer, and operator-skill documentation.
+- [ ] I updated both unreleased changelog files for user-visible changes, compatibility effects, removals, or security effects.
+- [ ] I documented every new timeout, retry, pagination or result limit, truncation, fallback, or downgrade and its evidence.
+- [ ] I did not add passwords, JWTs, `~/.javdb-cli/auth.json`, proxy credentials, private URLs, local state, or private API responses.
+- [ ] I updated migration guidance for every breaking change.


### PR DESCRIPTION
## Summary by Sourcery

引入标准化的 GitHub 模板，用于报告问题和提交 pull request。

Documentation（文档）:
- 添加结构化的缺陷报告和功能请求 Issue 模板，强调安全性、环境细节以及受影响的接口。
- 添加 pull request 模板，引导作者记录改动范围、兼容性、验证步骤以及更新的变更日志/文档。

Chores（维护杂项）:
- 配置 GitHub Issue 模板的路由，禁用空白 Issue，并将用户引导到 Discussions 处理一般问题，以及引导到私密渠道提交安全相关报告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce standardized GitHub templates for reporting issues and submitting pull requests.

Documentation:
- Add structured bug report and feature request issue templates emphasizing safety, environment details, and affected interfaces.
- Add a pull request template guiding authors to document scope, compatibility, verification steps, and changelog/documentation updates.

Chores:
- Configure GitHub issue template routing to disable blank issues and direct users to discussions for questions and private channels for security reports.

</details>

<!-- release-note
category: Documentation
breaking: false
summary: Add structured issue and pull-request templates.
none_reason:
-->
