### PR TITLE
fix(ci): label docs-only platform smoke skip

### DIFF
--- a/.github/workflows/platform-smoke.yml
+++ b/.github/workflows/platform-smoke.yml
@@ -39,7 +39,13 @@ jobs:
   packaged_binary_smoke:
     needs: classify_changes
     if: ${{ needs.classify_changes.outputs.docs_only != 'true' }}
-    name: Packaged binary smoke ${{ matrix.goos }}/${{ matrix.goarch }}
+    # job 级 if 会在矩阵展开前判断；纯文档改动被跳过时 matrix 尚不可用，
+    # 因此使用固定说明名，避免 GitHub UI 显示未展开的占位符。正常矩阵仍保留
+    # 既有的目标名称，以兼容分支保护所识别的六个平台检查。
+    name: >-
+      ${{ needs.classify_changes.outputs.docs_only == 'true' &&
+          'Packaged binary smoke (docs-only; intentionally skipped)' ||
+          format('Packaged binary smoke {0}/{1}', matrix.goos, matrix.goarch) }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read

--- a/scripts/test-workflows.sh
+++ b/scripts/test-workflows.sh
@@ -46,6 +46,9 @@ grep -F 'docs_only' "$quality_workflow" >/dev/null
 grep -F 'platform_smoke_gate:' "$platform_workflow" >/dev/null
 grep -F 'name: Platform smoke gate' "$platform_workflow" >/dev/null
 grep -F 'MATRIX_RESULT' "$platform_workflow" >/dev/null
+# job 级 if 在矩阵展开前执行；纯文档改动须显示说明名，完整变更仍须生成受保护的目标名。
+grep -F "'Packaged binary smoke (docs-only; intentionally skipped)'" "$platform_workflow" >/dev/null
+grep -F "format('Packaged binary smoke {0}/{1}', matrix.goos, matrix.goarch)" "$platform_workflow" >/dev/null
 
 # e2e workflow 必须排除纯文档/changelog/skills 路径,避免文档改动触发真实 API 冒烟。
 e2e_workflow="$repo_root/.github/workflows/e2e.yml"


### PR DESCRIPTION
## Summary / 概述

- Docs-only pull requests intentionally skip the six-platform packaged-binary matrix, but GitHub displayed the unresolved matrix expression as the skipped check name.
- Give that intentional skip a stable explanatory name while preserving the existing per-target names for normal matrix runs.
- Add a focused workflow regression assertion for both naming paths.

## Scope and compatibility / 范围与兼容性

No public CLI command, flag, Go SDK API, configuration, environment variable, output contract, operator skill, or release-artifact behavior changes. This only clarifies the GitHub Actions check name for an already intentional documentation-only skip; protected target names remain unchanged for non-documentation changes.

## Verification / 验证

```text
sh scripts/test-workflows.sh
actionlint .github/workflows/platform-smoke.yml
go test ./...
sh scripts/build.sh
pre-commit run --files .github/workflows/platform-smoke.yml scripts/test-workflows.sh
```

All commands passed. Real JavDB App API e2e was not run because this is a CI-workflow-only change.

## Release note declaration / Release note 声明

<!-- release-note
category: None
breaking: false
summary: Clarify the intentional docs-only platform smoke skip in CI.
none_reason: CI workflow naming and static regression coverage only; no user-facing CLI, SDK, configuration, or release behavior changes.
-->

## Checklist / 检查清单

- [x] The change is focused and linked to an issue when appropriate. / 改动目标明确，并在适用时关联 Issue。
- [x] I added or updated focused tests for changed behavior. / 我已为变更行为新增或更新聚焦测试。
- [x] I ran the relevant tests and recorded the results above. / 我已运行相关测试并在上方记录结果。
- [x] I updated the required CLI reference, SDK, README, maintainer, and operator-skill documentation. / 无需更新对外文档；工作流约束已在代码注释和回归测试中说明。
- [x] I completed the required release-note declaration above; `None` has a concrete reason when selected. / 我已填写上方必需的 release-note 声明；选择 `None` 时已提供具体理由。
- [x] I documented every new timeout, retry, pagination or result limit, truncation, fallback, or downgrade and its evidence. / 未新增此类限制或降级行为。
- [x] I did not add passwords, JWTs, `~/.javdb-cli/auth.json` contents, proxy credentials, private URLs, local state, or private API responses. / 我没有添加敏感信息或本机状态。
- [x] I updated migration guidance for every breaking change. / 无破坏性变更。

## Summary by Sourcery

在 GitHub Actions 中明确仅文档变更的平台 smoke 任务的 CI 行为和命名。

CI：
- 重命名平台 smoke 打包二进制任务，使其在仅文档变更时显示稳定且明确的跳过标签，同时在实际运行时保留按平台区分的矩阵检查名称。

测试：
- 扩展工作流回归脚本，以断言在平台 smoke 工作流中既保留仅文档变更的跳过标签，也保留按平台区分的矩阵任务名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify CI behavior and naming for docs-only platform smoke jobs in GitHub Actions.

CI:
- Rename the platform smoke packaged-binary job to show a stable, explicit skip label on docs-only changes while preserving per-platform matrix check names for real runs.

Tests:
- Extend the workflow regression script to assert both the docs-only skip label and the per-platform matrix job name remain present in the platform smoke workflow.

</details>