### PR TITLE
docs(release): prepare v0.5.0

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@ grouped by user outcome and carry inline PR or historical direct-commit sources;
 | Version | Date | Release notes |
 | --- | --- | --- |
 | Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
+| [v0.5.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.4.0...v0.5.0) | 2026-08-05 | [English](v0.5.0/en.md) · [简体中文](v0.5.0/zh-CN.md) |
 | [v0.4.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.3.0...v0.4.0) | 2026-08-05 | [English](v0.4.0/en.md) · [简体中文](v0.4.0/zh-CN.md) |
 | [v0.3.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.2.0...v0.3.0) | 2026-08-03 | [English](v0.3.0/en.md) · [简体中文](v0.3.0/zh-CN.md) |
 | [v0.2.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.1.1...v0.2.0) | 2026-07-23 | [English](v0.2.0/en.md) · [简体中文](v0.2.0/zh-CN.md) |

--- a/changelog/README.zh-CN.md
+++ b/changelog/README.zh-CN.md
@@ -5,6 +5,7 @@
 | 版本 | 日期 | 发布说明 |
 | --- | --- | --- |
 | Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
+| [v0.5.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.4.0...v0.5.0) | 2026-08-05 | [English](v0.5.0/en.md) · [简体中文](v0.5.0/zh-CN.md) |
 | [v0.4.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.3.0...v0.4.0) | 2026-08-05 | [English](v0.4.0/en.md) · [简体中文](v0.4.0/zh-CN.md) |
 | [v0.3.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.2.0...v0.3.0) | 2026-08-03 | [English](v0.3.0/en.md) · [简体中文](v0.3.0/zh-CN.md) |
 | [v0.2.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.1.1...v0.2.0) | 2026-07-23 | [English](v0.2.0/en.md) · [简体中文](v0.2.0/zh-CN.md) |

--- a/changelog/plans/v0.5.0.json
+++ b/changelog/plans/v0.5.0.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.5.0",
+  "previous_tag": "v0.4.0",
+  "compare_url": "https://github.com/FlanChanXwO/javdb-cli/compare/v0.4.0...v0.5.0",
+  "entries": [
+    {
+      "category": "Changed",
+      "breaking": true,
+      "english": "Move the public Go SDK import path from `github.com/FlanChanXwO/javdb-cli/javdb` to `github.com/FlanChanXwO/javdb-cli/sdk`. Replace the import path and resolve dependencies again; the package name (`javdb`), public API, and CLI behavior are unchanged.",
+      "zh_cn": "将公开 Go SDK 的导入路径从 `github.com/FlanChanXwO/javdb-cli/javdb` 迁移至 `github.com/FlanChanXwO/javdb-cli/sdk`。请替换导入路径并重新解析依赖；包名（`javdb`）、公开 API 与 CLI 行为保持不变。",
+      "sources": [
+        "https://github.com/FlanChanXwO/javdb-cli/pull/11"
+      ]
+    }
+  ]
+}

--- a/changelog/v0.5.0/en.md
+++ b/changelog/v0.5.0/en.md
@@ -1,0 +1,7 @@
+# v0.5.0 — 2026-08-05
+
+## Breaking changes
+
+- Move the public Go SDK import path from `github.com/FlanChanXwO/javdb-cli/javdb` to `github.com/FlanChanXwO/javdb-cli/sdk`. Replace the import path and resolve dependencies again; the package name (`javdb`), public API, and CLI behavior are unchanged. ([#11](https://github.com/FlanChanXwO/javdb-cli/pull/11))
+
+**Full Changelog**: [v0.4.0...v0.5.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.4.0...v0.5.0)

--- a/changelog/v0.5.0/zh-CN.md
+++ b/changelog/v0.5.0/zh-CN.md
@@ -1,0 +1,7 @@
+# v0.5.0 — 2026-08-05
+
+## 破坏性变更
+
+- 将公开 Go SDK 的导入路径从 `github.com/FlanChanXwO/javdb-cli/javdb` 迁移至 `github.com/FlanChanXwO/javdb-cli/sdk`。请替换导入路径并重新解析依赖；包名（`javdb`）、公开 API 与 CLI 行为保持不变。 ([#11](https://github.com/FlanChanXwO/javdb-cli/pull/11))
+
+**完整变更**：[v0.4.0...v0.5.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.4.0...v0.5.0)


### PR DESCRIPTION
## Summary

- Prepare the audited bilingual release notes for v0.5.0.
- Record the breaking public SDK import-path migration delivered by #11.

## Verification

```text
pre-commit run --all-files
go run ./scripts/releasenotes audit --repo FlanChanXwO/javdb-cli --from v0.4.0 --to origin/main --require-classified
go run ./scripts/releasenotes prepare --version 0.5.0 --previous v0.4.0 --date 2026-08-05 --plan changelog/plans/v0.5.0.json --audit <audit-report> --apply
go run ./scripts/releasenotes validate --version 0.5.0 --previous v0.4.0 --dir changelog/v0.5.0 --audit <audit-report>
```

## Release note declaration

<!-- release-note
category: None
breaking: false
summary: Prepare the audited v0.5.0 changelog for the already-classified SDK migration.
none_reason: This release-prep PR only records the audited outcome of PR #11 and adds no separate user-visible product change.
-->

## Summary by Sourcery

为 v0.5.0 版本添加经过审校的双语发行说明和更新日志元数据。

Documentation:
- 为 v0.5.0 添加英文和简体中文发行说明页面，记录公共 Go SDK 导入路径迁移。
- 更新变更日志索引，以引用新的 v0.5.0 发行说明和元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add audited bilingual release notes and changelog metadata for the v0.5.0 release.

Documentation:
- Add English and Simplified Chinese release note pages for v0.5.0 documenting the public Go SDK import-path migration.
- Update changelog indexes to reference the new v0.5.0 release notes and metadata.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 新增 v0.5.0（2026-08-05）版本记录及中英文发布说明。
  * 记录 Go SDK 公共导入路径由 `/javdb` 迁移至 `/sdk`，并标注为破坏性变更。
  * 明确包名、公共 API 及 CLI 行为保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->