### PR TITLE
fix(appapi): map rankings zone name to number and fix period parameter

### DIFF
--- a/internal/cli/rankings_cmd.go
+++ b/internal/cli/rankings_cmd.go
@@ -79,7 +79,7 @@ func newRankingsMoviesCmd(rf *rootFlags, aio *appIO) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&type_, "type", "censored", "censored|uncensored|western")
+	cmd.Flags().StringVar(&type_, "type", "censored", "censored|uncensored|western|fc2")
 	cmd.Flags().StringVar(&period, "period", "day", "day|week|month")
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
 	return cmd
@@ -99,7 +99,7 @@ func newRankingsActorsCmd(rf *rootFlags, aio *appIO) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			res, err := c.RankingsActors(context.Background(), javdb.ActorPeriod(period))
+			res, err := c.RankingsActors(context.Background(), javdb.RankingPeriod(period))
 			if err != nil {
 				return fmt.Errorf("rankings failed: %w", err)
 			}
@@ -138,7 +138,7 @@ func newRankingsPlaybackCmd(rf *rootFlags, aio *appIO) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&filterBy, "filter-by", "censored", "censored|uncensored|western")
+	cmd.Flags().StringVar(&filterBy, "filter-by", "censored", "censored|uncensored|western|fc2")
 	cmd.Flags().StringVar(&period, "period", "day", "day|week|month")
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
 	return cmd

--- a/internal/cli/rankings_cmd.go
+++ b/internal/cli/rankings_cmd.go
@@ -99,7 +99,7 @@ func newRankingsActorsCmd(rf *rootFlags, aio *appIO) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			res, err := c.RankingsActors(context.Background(), javdb.RankingPeriod(period))
+			res, err := c.RankingsActors(context.Background(), period)
 			if err != nil {
 				return fmt.Errorf("rankings failed: %w", err)
 			}

--- a/internal/javdb/appapi/rankings.go
+++ b/internal/javdb/appapi/rankings.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 )
 
-// ActorPeriod maps CLI day/week/month → API daily/weekly/monthly for actor rankings.
-func ActorPeriod(period string) string {
+// RankingPeriod maps CLI day/week/month → API daily/weekly/monthly for rankings.
+func RankingPeriod(period string) string {
 	switch period {
 	case "day":
 		return "daily"
@@ -61,9 +61,14 @@ func BuildTop250Params(zone, year string, startRank, page, limit int, ignoreWatc
 
 // RankingsMovies GET /api/v1/rankings
 func (c *Client) RankingsMovies(type_, period string) (SearchResult, error) {
+	t := type_
+	if z, ok := Zones[type_]; ok {
+		t = strconv.Itoa(z)
+	}
+
 	var data map[string]json.RawMessage
 	if err := c.GetJSON("/api/v1/rankings", map[string]string{
-		"type": type_, "period": period,
+		"type": t, "period": RankingPeriod(period),
 	}, &data); err != nil {
 		return nil, err
 	}
@@ -74,7 +79,7 @@ func (c *Client) RankingsMovies(type_, period string) (SearchResult, error) {
 func (c *Client) RankingsActors(period string) (SearchResult, error) {
 	var data map[string]json.RawMessage
 	if err := c.GetJSON("/api/v1/rankings/actors", map[string]string{
-		"type": period,
+		"type": RankingPeriod(period),
 	}, &data); err != nil {
 		return nil, err
 	}
@@ -83,9 +88,13 @@ func (c *Client) RankingsActors(period string) (SearchResult, error) {
 
 // RankingsPlayback GET /api/v1/rankings/playback
 func (c *Client) RankingsPlayback(filterBy, period string) (SearchResult, error) {
+	fb := filterBy
+	if z, ok := Zones[filterBy]; ok {
+		fb = strconv.Itoa(z)
+	}
 	var data map[string]json.RawMessage
 	if err := c.GetJSON("/api/v1/rankings/playback", map[string]string{
-		"filter_by": filterBy, "period": period,
+		"filter_by": fb, "period": RankingPeriod(period),
 	}, &data); err != nil {
 		return nil, err
 	}

--- a/internal/javdb/appapi/rankings.go
+++ b/internal/javdb/appapi/rankings.go
@@ -20,6 +20,19 @@ func RankingPeriod(period string) string {
 	}
 }
 
+// ActorPeriod maps CLI day/week/month → API daily/weekly/monthly for actor rankings.
+// Deprecated: Use RankingPeriod instead.
+func ActorPeriod(period string) string {
+	return RankingPeriod(period)
+}
+
+func normalizeZone(zone string) string {
+	if z, ok := Zones[zone]; ok {
+		return strconv.Itoa(z)
+	}
+	return zone
+}
+
 // BuildTop250Params builds query for GET /api/v1/movies/top.
 // year wins over zone when both set. Empty both → type=all.
 func BuildTop250Params(zone, year string, startRank, page, limit int, ignoreWatched bool) (map[string]string, error) {
@@ -61,21 +74,16 @@ func BuildTop250Params(zone, year string, startRank, page, limit int, ignoreWatc
 
 // RankingsMovies GET /api/v1/rankings
 func (c *Client) RankingsMovies(type_, period string) (SearchResult, error) {
-	t := type_
-	if z, ok := Zones[type_]; ok {
-		t = strconv.Itoa(z)
-	}
-
 	var data map[string]json.RawMessage
 	if err := c.GetJSON("/api/v1/rankings", map[string]string{
-		"type": t, "period": RankingPeriod(period),
+		"type": normalizeZone(type_), "period": RankingPeriod(period),
 	}, &data); err != nil {
 		return nil, err
 	}
 	return SearchResult(data), nil
 }
 
-// RankingsActors GET /api/v1/rankings/actors — period must be daily|weekly|monthly.
+// RankingsActors GET /api/v1/rankings/actors — period accepts day|week|month or daily|weekly|monthly.
 func (c *Client) RankingsActors(period string) (SearchResult, error) {
 	var data map[string]json.RawMessage
 	if err := c.GetJSON("/api/v1/rankings/actors", map[string]string{
@@ -88,13 +96,9 @@ func (c *Client) RankingsActors(period string) (SearchResult, error) {
 
 // RankingsPlayback GET /api/v1/rankings/playback
 func (c *Client) RankingsPlayback(filterBy, period string) (SearchResult, error) {
-	fb := filterBy
-	if z, ok := Zones[filterBy]; ok {
-		fb = strconv.Itoa(z)
-	}
 	var data map[string]json.RawMessage
 	if err := c.GetJSON("/api/v1/rankings/playback", map[string]string{
-		"filter_by": fb, "period": RankingPeriod(period),
+		"filter_by": normalizeZone(filterBy), "period": RankingPeriod(period),
 	}, &data); err != nil {
 		return nil, err
 	}

--- a/internal/javdb/appapi/rankings_test.go
+++ b/internal/javdb/appapi/rankings_test.go
@@ -10,6 +10,9 @@ func TestRankingPeriod(t *testing.T) {
 	if RankingPeriod("day") != "daily" || RankingPeriod("week") != "weekly" || RankingPeriod("month") != "monthly" {
 		t.Fatal("RankingPeriod mapping")
 	}
+	if ActorPeriod("day") != "daily" || ActorPeriod("week") != "weekly" || ActorPeriod("month") != "monthly" {
+		t.Fatal("ActorPeriod mapping")
+	}
 }
 
 func TestBuildTop250Params(t *testing.T) {

--- a/internal/javdb/appapi/rankings_test.go
+++ b/internal/javdb/appapi/rankings_test.go
@@ -1,10 +1,14 @@
 package appapi
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
 
-func TestActorPeriod(t *testing.T) {
-	if ActorPeriod("day") != "daily" || ActorPeriod("week") != "weekly" || ActorPeriod("month") != "monthly" {
-		t.Fatal("mapping")
+func TestRankingPeriod(t *testing.T) {
+	if RankingPeriod("day") != "daily" || RankingPeriod("week") != "weekly" || RankingPeriod("month") != "monthly" {
+		t.Fatal("RankingPeriod mapping")
 	}
 }
 
@@ -20,5 +24,83 @@ func TestBuildTop250Params(t *testing.T) {
 	p, err = BuildTop250Params("censored", "2023", 1, 1, 20, false)
 	if err != nil || p["type"] != "year" || p["type_value"] != "2023" {
 		t.Fatalf("year should win: %v %v", p, err)
+	}
+}
+
+func TestRankingsMoviesQueryMapping(t *testing.T) {
+	var gotType, gotPeriod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotType = r.URL.Query().Get("type")
+		gotPeriod = r.URL.Query().Get("period")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{"movies":[]}}`))
+	}))
+	defer server.Close()
+
+	client, err := New(Options{Host: server.URL})
+	if err != nil {
+		t.Fatalf("New client: %v", err)
+	}
+
+	tests := []struct {
+		input      string
+		period     string
+		wantType   string
+		wantPeriod string
+	}{
+		{"censored", "day", "0", "daily"},
+		{"uncensored", "week", "1", "weekly"},
+		{"western", "month", "2", "monthly"},
+		{"fc2", "day", "3", "daily"},
+		{"2", "daily", "2", "daily"},
+	}
+
+	for _, tt := range tests {
+		_, err := client.RankingsMovies(tt.input, tt.period)
+		if err != nil {
+			t.Fatalf("RankingsMovies(%q, %q) error: %v", tt.input, tt.period, err)
+		}
+		if gotType != tt.wantType || gotPeriod != tt.wantPeriod {
+			t.Errorf("RankingsMovies(%q, %q) got type=%q, period=%q; want type=%q, period=%q",
+				tt.input, tt.period, gotType, gotPeriod, tt.wantType, tt.wantPeriod)
+		}
+	}
+}
+
+func TestRankingsPlaybackQueryMapping(t *testing.T) {
+	var gotFilterBy, gotPeriod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotFilterBy = r.URL.Query().Get("filter_by")
+		gotPeriod = r.URL.Query().Get("period")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{"movies":[]}}`))
+	}))
+	defer server.Close()
+
+	client, err := New(Options{Host: server.URL})
+	if err != nil {
+		t.Fatalf("New client: %v", err)
+	}
+
+	tests := []struct {
+		input      string
+		period     string
+		wantFilter string
+		wantPeriod string
+	}{
+		{"western", "day", "2", "daily"},
+		{"censored", "week", "0", "weekly"},
+		{"1", "month", "1", "monthly"},
+	}
+
+	for _, tt := range tests {
+		_, err := client.RankingsPlayback(tt.input, tt.period)
+		if err != nil {
+			t.Fatalf("RankingsPlayback(%q, %q) error: %v", tt.input, tt.period, err)
+		}
+		if gotFilterBy != tt.wantFilter || gotPeriod != tt.wantPeriod {
+			t.Errorf("RankingsPlayback(%q, %q) got filter_by=%q, period=%q; want filter_by=%q, period=%q",
+				tt.input, tt.period, gotFilterBy, gotPeriod, tt.wantFilter, tt.wantPeriod)
+		}
 	}
 }

--- a/sdk/rankings.go
+++ b/sdk/rankings.go
@@ -6,8 +6,8 @@ import (
 	"github.com/FlanChanXwO/javdb-cli/internal/javdb/appapi"
 )
 
-// ActorPeriod re-export.
-func ActorPeriod(period string) string { return appapi.ActorPeriod(period) }
+// RankingPeriod re-export.
+func RankingPeriod(period string) string { return appapi.RankingPeriod(period) }
 
 // RankingsMovies fetches movie rankings.
 func (c *Client) RankingsMovies(ctx context.Context, type_, period string) (SearchResult, error) {
@@ -15,7 +15,7 @@ func (c *Client) RankingsMovies(ctx context.Context, type_, period string) (Sear
 	return c.api.RankingsMovies(type_, period)
 }
 
-// RankingsActors fetches actor rankings (period already daily/weekly/monthly or use ActorPeriod).
+// RankingsActors fetches actor rankings (period already daily/weekly/monthly or use RankingPeriod).
 func (c *Client) RankingsActors(ctx context.Context, period string) (SearchResult, error) {
 	_ = ctx
 	return c.api.RankingsActors(period)

--- a/sdk/rankings.go
+++ b/sdk/rankings.go
@@ -9,6 +9,10 @@ import (
 // RankingPeriod re-export.
 func RankingPeriod(period string) string { return appapi.RankingPeriod(period) }
 
+// ActorPeriod is a deprecated alias for RankingPeriod.
+// Deprecated: Use RankingPeriod instead.
+func ActorPeriod(period string) string { return appapi.ActorPeriod(period) }
+
 // RankingsMovies fetches movie rankings.
 func (c *Client) RankingsMovies(ctx context.Context, type_, period string) (SearchResult, error) {
 	_ = ctx


### PR DESCRIPTION
## Summary / 概述

This PR fixes the movie and playback rankings endpoints. Specifically, it maps textual zone names (e.g., `censored`, `uncensored`, `western`, `fc2`) to their corresponding API numeric identifiers before sending requests to the JavDB App API. It also updates the rankings commands to use `RankingPeriod` (renamed from `ActorPeriod`) for proper query parameter mapping.

## Scope and compatibility / 范围与兼容性

- **CLI Commands / Flags**:
  - `javdb rankings movies --type` and `javdb rankings playback --filter-by` now correctly accept and resolve textual zones (including the newly added `fc2` option).
- **Public Go SDK**:
  - Renamed and re-exported `ActorPeriod` to `RankingPeriod` in the public `javdb` facade.

## Verification / 验证

Successfully ran unit tests verifying query mapping behavior for both movies and playback endpoints:

```text
go test ./...
```
```text
ok  	github.com/FlanChanXwO/javdb-cli/internal/cli	1.528s
ok  	github.com/FlanChanXwO/javdb-cli/internal/javdb/appapi	1.098s
ok  	github.com/FlanChanXwO/javdb-cli/sdk	(cached)
```

## Release note declaration / Release note 声明

<!-- release-note
category: Fixed
breaking: false
summary: Map textual rankings zones (e.g. western, fc2) to API numeric types and fix rankings period parameters.
none_reason:
-->

## Checklist / 检查清单

- [x] The change is focused and linked to an issue when appropriate.
- [x] I added or updated focused tests for changed behavior.
- [x] I ran the relevant tests and recorded the results above.
- [x] I updated the required CLI reference, SDK, README, maintainer, and operator-skill documentation.
- [x] I completed the required release-note declaration above.
- [x] I documented every new timeout, retry, pagination or result limit, truncation, fallback, or downgrade and its evidence.
- [x] I did not add passwords, JWTs, `~/.javdb-cli/auth.json` contents, proxy credentials, private URLs, local state, or private API responses.
- [x] I updated migration guidance for every breaking change.

## Summary by Sourcery

修复电影、演员和播放的排行榜 API 查询映射，并更新 CLI 和 SDK 的命名以使用 RankingPeriod。

新功能：
- 允许排行榜中的电影和播放 CLI 命令在现有区域选项基础上额外接受 fc2 区域选项。

错误修复：
- 为电影和播放排行榜请求，将文本形式的区域名称映射为数值类型/`filter_by` 值。
- 确保所有排行榜端点中的排行榜周期值能够从 day/week/month 转换为 daily/weekly/monthly。

改进：
- 将 `ActorPeriod` 辅助工具重命名为 `RankingPeriod`，并在 SDK 中重新导出，以在所有排行榜端点中保持术语一致。

测试：
- 添加集成风格测试，通过测试 HTTP 服务器验证电影和播放排行榜的查询参数映射。
- 更新周期映射的单元测试，以覆盖重命名后的 `RankingPeriod` 辅助工具。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix rankings API query mapping for movies, actors, and playback, and update CLI and SDK naming to use RankingPeriod.

New Features:
- Allow rankings movies and playback CLI commands to accept the fc2 zone option alongside existing zones.

Bug Fixes:
- Map textual zone names to numeric type/filter_by values for movie and playback rankings requests.
- Ensure rankings period values are translated from day/week/month to daily/weekly/monthly for all rankings endpoints.

Enhancements:
- Rename the ActorPeriod helper to RankingPeriod and re-export it in the SDK for consistent terminology across rankings endpoints.

Tests:
- Add integration-style tests to verify query parameter mapping for movie and playback rankings against a test HTTP server.
- Update period-mapping unit test to cover the renamed RankingPeriod helper.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 排行榜类型筛选新增 `fc2` 选项。
  * 电影、演员和播放榜单支持统一的日、周、月周期筛选。
  * 榜单区域与筛选条件可更准确地传递并应用。

* **改进**
  * 更新排行榜周期辅助接口名称，提升电影、演员和播放榜单的一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->