### PR TITLE
feat(cli): add --json flag to rankings and top250 commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Use tabular output interactively and `--json` when a command exposes it and an
 agent or script needs stable fields:
 
 ```bash
-javdb rankings movies --period week
+javdb rankings movies --period week --json
 javdb actor 山手梨愛 --main m --has-magnets --json
 javdb lists search 巨乳 --zone all --json
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -128,7 +128,7 @@ javdb download SSIS-589 --thumbnail ./thumb.jpg --preview-image ./preview-0.jpg 
 交互时使用表格输出；命令支持时，Agent 或脚本可使用 `--json` 获取稳定字段：
 
 ```bash
-javdb rankings movies --period week
+javdb rankings movies --period week --json
 javdb actor 山手梨愛 --main m --has-magnets --json
 javdb lists search 巨乳 --zone all --json
 ```

--- a/docs/en/cli-reference.md
+++ b/docs/en/cli-reference.md
@@ -124,9 +124,9 @@ public or user list.
 
 ```bash
 javdb magnets NUMBER [--id] [--cnsub] [--hd] [--min-size SIZE] [--best] [--json]
-javdb rankings movies [--type TYPE] [--period day|week|month] [--has-magnets]
-javdb rankings actors [--period day|week|month]
-javdb rankings playback [--filter-by TYPE] [--period day|week|month] [--has-magnets]
+javdb rankings movies [--type TYPE] [--period day|week|month] [--has-magnets] [--json]
+javdb rankings actors [--period day|week|month] [--json]
+javdb rankings playback [--filter-by TYPE] [--period day|week|month] [--has-magnets] [--json]
 javdb top250 [--zone ZONE] [--year YYYY] [--from RANK] [--page N] [--limit N] \
   [--ignore-watched] [--has-magnets]
 
@@ -138,7 +138,9 @@ javdb mark NUMBER --watched|--want [--score N] [--content TEXT] [--id]
 javdb unmark NUMBER [--id]
 ```
 
-`magnets` works without login and falls back to anonymous when a saved token is
+`rankings movies` and `rankings playback` emit `{"movies":[...]}` with `--json`;
+`rankings actors` emits `{"actors":[...]}`. These result-only objects are emitted
+after any `--has-magnets` filtering. `magnets` works without login and falls back to anonymous when a saved token is
 rejected. `top250` needs authentication. `--best` chooses from the returned
 magnet set; it does not download anything. `mark` and `unmark` change remote
 watch/want state. `mark` requires exactly one of `--watched` or `--want`; obtain

--- a/docs/en/cli-reference.md
+++ b/docs/en/cli-reference.md
@@ -128,7 +128,7 @@ javdb rankings movies [--type TYPE] [--period day|week|month] [--has-magnets] [-
 javdb rankings actors [--period day|week|month] [--json]
 javdb rankings playback [--filter-by TYPE] [--period day|week|month] [--has-magnets] [--json]
 javdb top250 [--zone ZONE] [--year YYYY] [--from RANK] [--page N] [--limit N] \
-  [--ignore-watched] [--has-magnets]
+  [--ignore-watched] [--has-magnets] [--json]
 
 javdb watched [--has-magnets]
 javdb want [--has-magnets]
@@ -138,7 +138,7 @@ javdb mark NUMBER --watched|--want [--score N] [--content TEXT] [--id]
 javdb unmark NUMBER [--id]
 ```
 
-`rankings movies` and `rankings playback` emit `{"movies":[...]}` with `--json`;
+`rankings movies`, `rankings playback`, and `top250` emit `{"movies":[...]}` with `--json`;
 `rankings actors` emits `{"actors":[...]}`. These result-only objects are emitted
 after any `--has-magnets` filtering. `magnets` works without login and falls back to anonymous when a saved token is
 rejected. `top250` needs authentication. `--best` chooses from the returned

--- a/docs/zh-CN/cli-reference.md
+++ b/docs/zh-CN/cli-reference.md
@@ -111,7 +111,7 @@ javdb rankings movies [--type TYPE] [--period day|week|month] [--has-magnets] [-
 javdb rankings actors [--period day|week|month] [--json]
 javdb rankings playback [--filter-by TYPE] [--period day|week|month] [--has-magnets] [--json]
 javdb top250 [--zone ZONE] [--year YYYY] [--from RANK] [--page N] [--limit N] \
-  [--ignore-watched] [--has-magnets]
+  [--ignore-watched] [--has-magnets] [--json]
 
 javdb watched [--has-magnets]
 javdb want [--has-magnets]
@@ -121,7 +121,7 @@ javdb mark NUMBER --watched|--want [--score N] [--content TEXT] [--id]
 javdb unmark NUMBER [--id]
 ```
 
-`rankings movies` 与 `rankings playback` 使用 `--json` 时输出 `{"movies":[...]}`；
+`rankings movies`、`rankings playback` 与 `top250` 使用 `--json` 时输出 `{"movies":[...]}`；
 `rankings actors` 输出 `{"actors":[...]}`。这些只含结果的对象会在 `--has-magnets`
 过滤后输出。`magnets` 无需登录即可使用，token 失效时自动回退匿名请求。`top250` 需要登录。
 `--best` 只从服务端返回的磁力集中选择，不会下载。

--- a/docs/zh-CN/cli-reference.md
+++ b/docs/zh-CN/cli-reference.md
@@ -107,9 +107,9 @@ javdb lists related NUMBER [--id] [--page N] [--limit N] [--json]
 
 ```bash
 javdb magnets NUMBER [--id] [--cnsub] [--hd] [--min-size SIZE] [--best] [--json]
-javdb rankings movies [--type TYPE] [--period day|week|month] [--has-magnets]
-javdb rankings actors [--period day|week|month]
-javdb rankings playback [--filter-by TYPE] [--period day|week|month] [--has-magnets]
+javdb rankings movies [--type TYPE] [--period day|week|month] [--has-magnets] [--json]
+javdb rankings actors [--period day|week|month] [--json]
+javdb rankings playback [--filter-by TYPE] [--period day|week|month] [--has-magnets] [--json]
 javdb top250 [--zone ZONE] [--year YYYY] [--from RANK] [--page N] [--limit N] \
   [--ignore-watched] [--has-magnets]
 
@@ -121,7 +121,9 @@ javdb mark NUMBER --watched|--want [--score N] [--content TEXT] [--id]
 javdb unmark NUMBER [--id]
 ```
 
-`magnets` 无需登录即可使用，token 失效时自动回退匿名请求。`top250` 需要登录。
+`rankings movies` 与 `rankings playback` 使用 `--json` 时输出 `{"movies":[...]}`；
+`rankings actors` 输出 `{"actors":[...]}`。这些只含结果的对象会在 `--has-magnets`
+过滤后输出。`magnets` 无需登录即可使用，token 失效时自动回退匿名请求。`top250` 需要登录。
 `--best` 只从服务端返回的磁力集中选择，不会下载。
 `mark`/`unmark` 会改写远程的看过/想看状态；`mark` 必须且只能传入
 `--watched` 或 `--want` 之一。替他人或其他账号操作前必须确认。

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -115,6 +115,8 @@ else
   echo "== top250 =="
   out=$(run top250 --zone censored --limit 1)
   assert_substring "top250 has ranked row" "$out" "#1"
+  out=$(run top250 --zone censored --limit 1 --json)
+  assert_json "top250 --json ok" "$out" "'movies' in d and len(d['movies']) == 1"
 
   echo "== watched / want / recent =="
   out=$(run watched)

--- a/internal/cli/rankings_cmd.go
+++ b/internal/cli/rankings_cmd.go
@@ -42,6 +42,9 @@ func PrintNamedNoCount(w io.Writer, errW io.Writer, items []map[string]any) {
 }
 
 func renderRankingsMovies(aio *appIO, movies []map[string]any, asJSON bool) error {
+	if movies == nil {
+		movies = []map[string]any{}
+	}
 	if asJSON {
 		return EmitJSON(aio.out, map[string]any{"movies": movies})
 	}
@@ -50,6 +53,9 @@ func renderRankingsMovies(aio *appIO, movies []map[string]any, asJSON bool) erro
 }
 
 func renderRankingsActors(aio *appIO, actors []map[string]any, asJSON bool) error {
+	if actors == nil {
+		actors = []map[string]any{}
+	}
 	if asJSON {
 		return EmitJSON(aio.out, map[string]any{"actors": actors})
 	}
@@ -180,6 +186,9 @@ func newTop250Cmd(rf *rootFlags, aio *appIO) *cobra.Command {
 				movies := res.Movies()
 				if hasMagnets {
 					movies = FilterHasMagnets(movies)
+				}
+				if movies == nil {
+					movies = []map[string]any{}
 				}
 				if asJSON {
 					return EmitJSON(aio.out, map[string]any{"movies": movies})

--- a/internal/cli/rankings_cmd.go
+++ b/internal/cli/rankings_cmd.go
@@ -41,6 +41,22 @@ func PrintNamedNoCount(w io.Writer, errW io.Writer, items []map[string]any) {
 	}
 }
 
+func renderRankingsMovies(aio *appIO, movies []map[string]any, asJSON bool) error {
+	if asJSON {
+		return EmitJSON(aio.out, map[string]any{"movies": movies})
+	}
+	PrintMovies(aio.out, aio.err, movies)
+	return nil
+}
+
+func renderRankingsActors(aio *appIO, actors []map[string]any, asJSON bool) error {
+	if asJSON {
+		return EmitJSON(aio.out, map[string]any{"actors": actors})
+	}
+	PrintNamedNoCount(aio.out, aio.err, actors)
+	return nil
+}
+
 func newRankingsCmd(rf *rootFlags, aio *appIO) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "rankings",
@@ -54,7 +70,7 @@ func newRankingsCmd(rf *rootFlags, aio *appIO) *cobra.Command {
 
 func newRankingsMoviesCmd(rf *rootFlags, aio *appIO) *cobra.Command {
 	var type_, period string
-	var hasMagnets bool
+	var hasMagnets, asJSON bool
 	cmd := &cobra.Command{
 		Use:   "movies",
 		Short: "Movie rankings",
@@ -75,18 +91,19 @@ func newRankingsMoviesCmd(rf *rootFlags, aio *appIO) *cobra.Command {
 			if hasMagnets {
 				movies = FilterHasMagnets(movies)
 			}
-			PrintMovies(aio.out, aio.err, movies)
-			return nil
+			return renderRankingsMovies(aio, movies, asJSON)
 		},
 	}
 	cmd.Flags().StringVar(&type_, "type", "censored", "censored|uncensored|western")
 	cmd.Flags().StringVar(&period, "period", "day", "day|week|month")
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	return cmd
 }
 
 func newRankingsActorsCmd(rf *rootFlags, aio *appIO) *cobra.Command {
 	var period string
+	var asJSON bool
 	cmd := &cobra.Command{
 		Use:   "actors",
 		Short: "Actor rankings",
@@ -103,17 +120,17 @@ func newRankingsActorsCmd(rf *rootFlags, aio *appIO) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("rankings failed: %w", err)
 			}
-			PrintNamedNoCount(aio.out, aio.err, res.Named("actors"))
-			return nil
+			return renderRankingsActors(aio, res.Named("actors"), asJSON)
 		},
 	}
 	cmd.Flags().StringVar(&period, "period", "day", "day|week|month")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	return cmd
 }
 
 func newRankingsPlaybackCmd(rf *rootFlags, aio *appIO) *cobra.Command {
 	var filterBy, period string
-	var hasMagnets bool
+	var hasMagnets, asJSON bool
 	cmd := &cobra.Command{
 		Use:   "playback",
 		Short: "Playback rankings",
@@ -134,13 +151,13 @@ func newRankingsPlaybackCmd(rf *rootFlags, aio *appIO) *cobra.Command {
 			if hasMagnets {
 				movies = FilterHasMagnets(movies)
 			}
-			PrintMovies(aio.out, aio.err, movies)
-			return nil
+			return renderRankingsMovies(aio, movies, asJSON)
 		},
 	}
 	cmd.Flags().StringVar(&filterBy, "filter-by", "censored", "censored|uncensored|western")
 	cmd.Flags().StringVar(&period, "period", "day", "day|week|month")
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	return cmd
 }
 

--- a/internal/cli/rankings_cmd.go
+++ b/internal/cli/rankings_cmd.go
@@ -164,7 +164,7 @@ func newRankingsPlaybackCmd(rf *rootFlags, aio *appIO) *cobra.Command {
 func newTop250Cmd(rf *rootFlags, aio *appIO) *cobra.Command {
 	var zone, year string
 	var startRank, page, limit int
-	var ignoreWatched, hasMagnets bool
+	var ignoreWatched, hasMagnets, asJSON bool
 	cmd := &cobra.Command{
 		Use:   "top250",
 		Short: "TOP250 list (needs login)",
@@ -174,12 +174,15 @@ func newTop250Cmd(rf *rootFlags, aio *appIO) *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("top250 failed: %w", err)
 				}
-				if gen := resRawString(res, "generated_at"); gen != "" {
+				if gen := resRawString(res, "generated_at"); gen != "" && !asJSON {
 					fmt.Fprintf(aio.err, "# generated_at=%s\n", gen)
 				}
 				movies := res.Movies()
 				if hasMagnets {
 					movies = FilterHasMagnets(movies)
+				}
+				if asJSON {
+					return EmitJSON(aio.out, map[string]any{"movies": movies})
 				}
 				PrintRankedMovies(aio.out, aio.err, movies)
 				return nil
@@ -193,6 +196,7 @@ func newTop250Cmd(rf *rootFlags, aio *appIO) *cobra.Command {
 	cmd.Flags().IntVar(&limit, "limit", 20, "Page size")
 	cmd.Flags().BoolVar(&ignoreWatched, "ignore-watched", false, "Skip already watched titles")
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	return cmd
 }
 

--- a/internal/cli/rankings_cmd_test.go
+++ b/internal/cli/rankings_cmd_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -19,5 +20,41 @@ func TestRankingsTop250Help(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("%v: %s", args, errb.String())
 		}
+		if len(args) == 3 && !strings.Contains(out.String(), "--json") {
+			t.Fatalf("%v: missing --json", args)
+		}
+	}
+}
+
+func TestRenderRankingsMoviesJSONFiltersMagnets(t *testing.T) {
+	aio := &appIO{out: &bytes.Buffer{}, err: &bytes.Buffer{}}
+	movies := []map[string]any{
+		{"number": "HAS", "magnets_count": float64(1)},
+		{"number": "NONE", "magnets_count": float64(0)},
+	}
+	if err := renderRankingsMovies(aio, FilterHasMagnets(movies), true); err != nil {
+		t.Fatal(err)
+	}
+	var got map[string][]map[string]any
+	if err := json.Unmarshal(aio.out.(*bytes.Buffer).Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got["movies"]) != 1 || got["movies"][0]["number"] != "HAS" {
+		t.Fatalf("unexpected JSON: %#v", got)
+	}
+}
+
+func TestRenderRankingsActorsJSON(t *testing.T) {
+	aio := &appIO{out: &bytes.Buffer{}, err: &bytes.Buffer{}}
+	actors := []map[string]any{{"id": "actor-1", "name": "Actor"}}
+	if err := renderRankingsActors(aio, actors, true); err != nil {
+		t.Fatal(err)
+	}
+	var got map[string][]map[string]any
+	if err := json.Unmarshal(aio.out.(*bytes.Buffer).Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got["actors"]) != 1 || got["actors"][0]["id"] != "actor-1" {
+		t.Fatalf("unexpected JSON: %#v", got)
 	}
 }

--- a/internal/cli/rankings_cmd_test.go
+++ b/internal/cli/rankings_cmd_test.go
@@ -75,3 +75,40 @@ func TestTop250JSONOutput(t *testing.T) {
 		t.Fatalf("unexpected JSON: %#v", got)
 	}
 }
+
+func TestRenderRankingsJSONNilNormalization(t *testing.T) {
+	aioMovies := &appIO{out: &bytes.Buffer{}, err: &bytes.Buffer{}}
+	if err := renderRankingsMovies(aioMovies, nil, true); err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(aioMovies.out.(*bytes.Buffer).String()) != `{"movies":[]}` {
+		t.Fatalf("expected {\"movies\":[]}, got %q", aioMovies.out.(*bytes.Buffer).String())
+	}
+
+	aioActors := &appIO{out: &bytes.Buffer{}, err: &bytes.Buffer{}}
+	if err := renderRankingsActors(aioActors, nil, true); err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(aioActors.out.(*bytes.Buffer).String()) != `{"actors":[]}` {
+		t.Fatalf("expected {\"actors\":[]}, got %q", aioActors.out.(*bytes.Buffer).String())
+	}
+}
+
+func TestRenderRankingsPlaybackJSONFiltersMagnets(t *testing.T) {
+	aio := &appIO{out: &bytes.Buffer{}, err: &bytes.Buffer{}}
+	playbackMovies := []map[string]any{
+		{"number": "PB-HAS", "magnets_count": float64(3)},
+		{"number": "PB-NONE", "magnets_count": float64(0)},
+	}
+	filtered := FilterHasMagnets(playbackMovies)
+	if err := renderRankingsMovies(aio, filtered, true); err != nil {
+		t.Fatal(err)
+	}
+	var got map[string][]map[string]any
+	if err := json.Unmarshal(aio.out.(*bytes.Buffer).Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got["movies"]) != 1 || got["movies"][0]["number"] != "PB-HAS" {
+		t.Fatalf("unexpected JSON for playback: %#v", got)
+	}
+}

--- a/internal/cli/rankings_cmd_test.go
+++ b/internal/cli/rankings_cmd_test.go
@@ -20,7 +20,7 @@ func TestRankingsTop250Help(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("%v: %s", args, errb.String())
 		}
-		if len(args) == 3 && !strings.Contains(out.String(), "--json") {
+		if (len(args) == 3 || args[0] == "top250") && !strings.Contains(out.String(), "--json") {
 			t.Fatalf("%v: missing --json", args)
 		}
 	}
@@ -55,6 +55,23 @@ func TestRenderRankingsActorsJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(got["actors"]) != 1 || got["actors"][0]["id"] != "actor-1" {
+		t.Fatalf("unexpected JSON: %#v", got)
+	}
+}
+
+func TestTop250JSONOutput(t *testing.T) {
+	aio := &appIO{out: &bytes.Buffer{}, err: &bytes.Buffer{}}
+	movies := []map[string]any{
+		{"ranking": float64(1), "number": "SSIS-001", "id": "m1", "title": "Test Title"},
+	}
+	if err := EmitJSON(aio.out, map[string]any{"movies": movies}); err != nil {
+		t.Fatal(err)
+	}
+	var got map[string][]map[string]any
+	if err := json.Unmarshal(aio.out.(*bytes.Buffer).Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got["movies"]) != 1 || got["movies"][0]["number"] != "SSIS-001" {
 		t.Fatalf("unexpected JSON: %#v", got)
 	}
 }

--- a/skills/javdb-cli/references/discover.md
+++ b/skills/javdb-cli/references/discover.md
@@ -8,7 +8,7 @@
 4. 主题浏览：先 `javdb tags --zone ZONE` 取得准确标签，再 `javdb browse --tag TAG --json`。需要重建缓存时，用户应明确要求 `tags --refresh`。
 5. 合集：用 `javdb lists search QUERY` 找公开合集，用 `javdb list LIST_ID` 读取其中影片。不要将认证的“我的合集”默认命令 `javdb lists` 误作公开搜索。
 6. 磁力：`javdb magnets NUMBER --json` 无需登录即可获取磁力链接；已保存默认账号 token 时自动带上，token 失效则回退匿名。用户要求一条推荐结果时才加 `--best`；需要指定条件可用 `--cnsub`、`--hd`、`--min-size`，并在回应中说明过滤条件。
-7. 排行：`javdb rankings movies|actors|playback --json` 无需登录；影片排行的结果字段为 `movies`，演员排行为 `actors`。需要仅保留有磁力的影片时加 `--has-magnets`，不要把过滤后结果误称为完整榜单。
+7. 排行：`javdb rankings movies|actors|playback --json` 无需登录；`javdb top250 --json` 需要登录。影片排行的结果字段为 `movies`，演员排行为 `actors`。需要仅保留有磁力的影片时加 `--has-magnets`，不要把过滤后结果误称为完整榜单。
 8. 评论：`javdb comments NUMBER --page 1 --limit 20 --json` 每次只取所选一页；不要自动读取后续页，也不要把页面评论误称为全量评论。
 9. 媒体：只有用户明确要求写入本机文件时，才执行 `javdb download NUMBER --thumbnail PATH`、`--preview-image PATH` 或 `--preview-video PATH`。`--preview-image` 只下载首张预览图；路径必须是新的，不能替换已有文件。
 

--- a/skills/javdb-cli/references/discover.md
+++ b/skills/javdb-cli/references/discover.md
@@ -8,7 +8,7 @@
 4. 主题浏览：先 `javdb tags --zone ZONE` 取得准确标签，再 `javdb browse --tag TAG --json`。需要重建缓存时，用户应明确要求 `tags --refresh`。
 5. 合集：用 `javdb lists search QUERY` 找公开合集，用 `javdb list LIST_ID` 读取其中影片。不要将认证的“我的合集”默认命令 `javdb lists` 误作公开搜索。
 6. 磁力：`javdb magnets NUMBER --json` 无需登录即可获取磁力链接；已保存默认账号 token 时自动带上，token 失效则回退匿名。用户要求一条推荐结果时才加 `--best`；需要指定条件可用 `--cnsub`、`--hd`、`--min-size`，并在回应中说明过滤条件。
-7. 排行：`javdb rankings movies|actors|playback --json` 无需登录；`javdb top250 --json` 需要登录。影片排行的结果字段为 `movies`，演员排行为 `actors`。需要仅保留有磁力的影片时加 `--has-magnets`，不要把过滤后结果误称为完整榜单。
+7. 排行：`javdb rankings movies|actors|playback --json` 无需登录；`javdb top250 --json` 需要登录。影片与播放排行的结果字段为 `movies`，演员排行为 `actors`。需要仅保留有磁力的影片时加 `--has-magnets`，不要把过滤后结果误称为完整榜单。
 8. 评论：`javdb comments NUMBER --page 1 --limit 20 --json` 每次只取所选一页；不要自动读取后续页，也不要把页面评论误称为全量评论。
 9. 媒体：只有用户明确要求写入本机文件时，才执行 `javdb download NUMBER --thumbnail PATH`、`--preview-image PATH` 或 `--preview-video PATH`。`--preview-image` 只下载首张预览图；路径必须是新的，不能替换已有文件。
 

--- a/skills/javdb-cli/references/discover.md
+++ b/skills/javdb-cli/references/discover.md
@@ -8,7 +8,8 @@
 4. 主题浏览：先 `javdb tags --zone ZONE` 取得准确标签，再 `javdb browse --tag TAG --json`。需要重建缓存时，用户应明确要求 `tags --refresh`。
 5. 合集：用 `javdb lists search QUERY` 找公开合集，用 `javdb list LIST_ID` 读取其中影片。不要将认证的“我的合集”默认命令 `javdb lists` 误作公开搜索。
 6. 磁力：`javdb magnets NUMBER --json` 无需登录即可获取磁力链接；已保存默认账号 token 时自动带上，token 失效则回退匿名。用户要求一条推荐结果时才加 `--best`；需要指定条件可用 `--cnsub`、`--hd`、`--min-size`，并在回应中说明过滤条件。
-7. 评论：`javdb comments NUMBER --page 1 --limit 20 --json` 每次只取所选一页；不要自动读取后续页，也不要把页面评论误称为全量评论。
-8. 媒体：只有用户明确要求写入本机文件时，才执行 `javdb download NUMBER --thumbnail PATH`、`--preview-image PATH` 或 `--preview-video PATH`。`--preview-image` 只下载首张预览图；路径必须是新的，不能替换已有文件。
+7. 排行：`javdb rankings movies|actors|playback --json` 无需登录；影片排行的结果字段为 `movies`，演员排行为 `actors`。需要仅保留有磁力的影片时加 `--has-magnets`，不要把过滤后结果误称为完整榜单。
+8. 评论：`javdb comments NUMBER --page 1 --limit 20 --json` 每次只取所选一页；不要自动读取后续页，也不要把页面评论误称为全量评论。
+9. 媒体：只有用户明确要求写入本机文件时，才执行 `javdb download NUMBER --thumbnail PATH`、`--preview-image PATH` 或 `--preview-video PATH`。`--preview-image` 只下载首张预览图；路径必须是新的，不能替换已有文件。
 
 每个阶段先检查退出码；API 返回错误、空结果或认证失败均应如实呈现，而不是更换主机、代理、账号或关键字来“补救”。


### PR DESCRIPTION
## Summary / 概述

Adds `--json` flag support to `rankings` (`movies`, `actors`, `playback`) and `top250` commands, enabling machine-readable JSON output matching the format of existing filmography commands.

为 `rankings`（`movies`、`actors`、`playback`）与 `top250` 命令添加 `--json` 选项，输出与实体片单保持一致的结构化 JSON。

## Scope and compatibility / 范围与兼容性

- **CLI commands & flags**: `javdb rankings movies|actors|playback [--json]`, `javdb top250 [--json]`
- **Output contract**:
  - `rankings movies`, `rankings playback`, and `top250` emit `{"movies": [...]}` on stdout when `--json` is specified.
  - `rankings actors` emits `{"actors": [...]}` on stdout when `--json` is specified.
  - Suppresses `# generated_at` header line on stderr when `--json` is enabled.
- **Documentation & Skills**: Updated English/Chinese CLI reference files and `skills/javdb-cli/references/discover.md`.
- **Public SDK**: None (public SDK API unchanged).
- **Breaking changes**: None.

## Verification / 验证

```text
go test ./...
sh scripts/build.sh
```

- Ran `go test ./...` (including updated `TestRankingsTop250Help`, `TestRenderRankingsMoviesJSONFiltersMagnets`, `TestRenderRankingsActorsJSON`, and `TestTop250JSONOutput`).
- Ran `sh scripts/build.sh`.
- Added e2e assertion in `e2e/run.sh` for `top250 --zone censored --limit 1 --json`.

## Release note declaration / Release note 声明

<!-- release-note
category: Added
breaking: false
summary: Add --json flag support to rankings and top250 commands.
none_reason: 
-->

## Checklist / 检查清单

- [x] The change is focused and linked to an issue when appropriate. / 改动目标明确，并在适用时关联 Issue。
- [x] I added or updated focused tests for changed behavior. / 我已为变更行为新增或更新聚焦测试。
- [x] I ran the relevant tests and recorded the results above. / 我已运行相关测试并在上方记录结果。
- [x] I updated the required CLI reference, SDK, README, maintainer, and operator-skill documentation. / 我已更新所需的 CLI reference、SDK、README、维护者和 operator-skill 文档。
- [x] I completed the required release-note declaration above; `None` has a concrete reason when selected. / 我已填写上方必需的 release-note 声明；选择 `None` 时已提供具体理由。
- [x] I documented every new timeout, retry, pagination or result limit, truncation, fallback, or downgrade and its evidence. / 我已记录每项新增 timeout、retry、pagination 或结果限制、truncation、fallback 或 downgrade 及其证据。
- [x] I did not add passwords, JWTs, `~/.javdb-cli/auth.json` contents, proxy credentials, private URLs, local state, or private API responses. / 我没有添加密码、JWT、`~/.javdb-cli/auth.json` 内容、代理凭据、私有 URL、本地状态或私有 API 响应。
- [x] I updated migration guidance for every breaking change. / 我已为每个破坏性变更更新迁移指引。
