### PR TITLE
docs(release): prepare v0.5.1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Repository-wide default owner for future pull requests.
+# This requests the sole maintainer for paths without a more specific rule.
+* @FlanChanXwO

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,7 @@
 # Localized content: English / 中文
 name: Bug report / Bug 报告
 description: Report a reproducible problem in the CLI or public Go SDK. / 报告 CLI 或 public Go SDK 中可复现的问题。
-title: "[Bug]: "
+title: "[Bug] "
 labels:
   - bug
 body:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,7 +1,7 @@
 # Localized content: English / 中文
 name: Feature request / 功能请求
 description: Propose a focused improvement to javdb-cli. / 为 javdb-cli 提出明确的改进建议。
-title: "[Feature]: "
+title: "[Feature] "
 labels:
   - enhancement
 body:

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@ grouped by user outcome and carry inline PR or historical direct-commit sources;
 | Version | Date | Release notes |
 | --- | --- | --- |
 | Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
+| [v0.5.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.5.0...v0.5.1) | 2026-08-09 | [English](v0.5.1/en.md) · [简体中文](v0.5.1/zh-CN.md) |
 | [v0.5.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.4.0...v0.5.0) | 2026-08-05 | [English](v0.5.0/en.md) · [简体中文](v0.5.0/zh-CN.md) |
 | [v0.4.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.3.0...v0.4.0) | 2026-08-05 | [English](v0.4.0/en.md) · [简体中文](v0.4.0/zh-CN.md) |
 | [v0.3.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.2.0...v0.3.0) | 2026-08-03 | [English](v0.3.0/en.md) · [简体中文](v0.3.0/zh-CN.md) |

--- a/changelog/README.zh-CN.md
+++ b/changelog/README.zh-CN.md
@@ -5,6 +5,7 @@
 | 版本 | 日期 | 发布说明 |
 | --- | --- | --- |
 | Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
+| [v0.5.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.5.0...v0.5.1) | 2026-08-09 | [English](v0.5.1/en.md) · [简体中文](v0.5.1/zh-CN.md) |
 | [v0.5.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.4.0...v0.5.0) | 2026-08-05 | [English](v0.5.0/en.md) · [简体中文](v0.5.0/zh-CN.md) |
 | [v0.4.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.3.0...v0.4.0) | 2026-08-05 | [English](v0.4.0/en.md) · [简体中文](v0.4.0/zh-CN.md) |
 | [v0.3.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.2.0...v0.3.0) | 2026-08-03 | [English](v0.3.0/en.md) · [简体中文](v0.3.0/zh-CN.md) |

--- a/changelog/plans/v0.5.1.json
+++ b/changelog/plans/v0.5.1.json
@@ -14,7 +14,7 @@
     },
     {
       "category": "Fixed",
-      "english": "Fix movie and playback rankings query mapping by translating textual zones such as `censored`, `uncensored`, `western`, and `fc2` to the App API's numeric values, and normalize ranking periods consistently across ranking endpoints.",
+      "english": "Fix movie and playback rankings query mapping by translating textual zones such as `censored`, `uncensored`, `western`, and `fc2` to the App API's numeric values, and normalizing ranking periods consistently across ranking endpoints.",
       "zh_cn": "修复影片榜与播放榜的查询参数映射，将 `censored`、`uncensored`、`western`、`fc2` 等文本分区转换为 App API 所需的数字值，并统一各排行接口的周期归一化。",
       "sources": [
         "https://github.com/FlanChanXwO/javdb-cli/pull/13"

--- a/changelog/plans/v0.5.1.json
+++ b/changelog/plans/v0.5.1.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.5.1",
+  "previous_tag": "v0.5.0",
+  "compare_url": "https://github.com/FlanChanXwO/javdb-cli/compare/v0.5.0...v0.5.1",
+  "entries": [
+    {
+      "category": "Added",
+      "breaking": false,
+      "english": "Add `--json` output to the `rankings movies`, `rankings actors`, `rankings playback`, and `top250` commands, preserving `--has-magnets` filtering and stable `movies`/`actors` result keys.",
+      "zh_cn": "为 `rankings movies`、`rankings actors`、`rankings playback` 与 `top250` 命令新增 `--json` 输出，保留 `--has-magnets` 过滤，并提供稳定的 `movies`/`actors` 结果键。",
+      "sources": [
+        "https://github.com/FlanChanXwO/javdb-cli/pull/14"
+      ]
+    },
+    {
+      "category": "Fixed",
+      "english": "Fix movie and playback rankings query mapping by translating textual zones such as `censored`, `uncensored`, `western`, and `fc2` to the App API's numeric values, and normalize ranking periods consistently across ranking endpoints.",
+      "zh_cn": "修复影片榜与播放榜的查询参数映射，将 `censored`、`uncensored`、`western`、`fc2` 等文本分区转换为 App API 所需的数字值，并统一各排行接口的周期归一化。",
+      "sources": [
+        "https://github.com/FlanChanXwO/javdb-cli/pull/13"
+      ]
+    }
+  ],
+  "new_contributors": [
+    {
+      "login": "kanoshiou",
+      "profile_url": "https://github.com/kanoshiou",
+      "pull_number": 13,
+      "pull_url": "https://github.com/FlanChanXwO/javdb-cli/pull/13"
+    }
+  ]
+}

--- a/changelog/v0.5.1/en.md
+++ b/changelog/v0.5.1/en.md
@@ -6,7 +6,7 @@
 
 ## Fixed
 
-- Fix movie and playback rankings query mapping by translating textual zones such as `censored`, `uncensored`, `western`, and `fc2` to the App API's numeric values, and normalize ranking periods consistently across ranking endpoints. ([#13](https://github.com/FlanChanXwO/javdb-cli/pull/13))
+- Fix movie and playback rankings query mapping by translating textual zones such as `censored`, `uncensored`, `western`, and `fc2` to the App API's numeric values, and normalizing ranking periods consistently across ranking endpoints. ([#13](https://github.com/FlanChanXwO/javdb-cli/pull/13))
 
 ## New Contributors
 

--- a/changelog/v0.5.1/en.md
+++ b/changelog/v0.5.1/en.md
@@ -1,0 +1,15 @@
+# v0.5.1 — 2026-08-09
+
+## Added
+
+- Add `--json` output to the `rankings movies`, `rankings actors`, `rankings playback`, and `top250` commands, preserving `--has-magnets` filtering and stable `movies`/`actors` result keys. ([#14](https://github.com/FlanChanXwO/javdb-cli/pull/14))
+
+## Fixed
+
+- Fix movie and playback rankings query mapping by translating textual zones such as `censored`, `uncensored`, `western`, and `fc2` to the App API's numeric values, and normalize ranking periods consistently across ranking endpoints. ([#13](https://github.com/FlanChanXwO/javdb-cli/pull/13))
+
+## New Contributors
+
+- [@kanoshiou](https://github.com/kanoshiou) made their first contribution in [#13](https://github.com/FlanChanXwO/javdb-cli/pull/13).
+
+**Full Changelog**: [v0.5.0...v0.5.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.5.0...v0.5.1)

--- a/changelog/v0.5.1/zh-CN.md
+++ b/changelog/v0.5.1/zh-CN.md
@@ -1,0 +1,15 @@
+# v0.5.1 — 2026-08-09
+
+## 新增
+
+- 为 `rankings movies`、`rankings actors`、`rankings playback` 与 `top250` 命令新增 `--json` 输出，保留 `--has-magnets` 过滤，并提供稳定的 `movies`/`actors` 结果键。 ([#14](https://github.com/FlanChanXwO/javdb-cli/pull/14))
+
+## 修复
+
+- 修复影片榜与播放榜的查询参数映射，将 `censored`、`uncensored`、`western`、`fc2` 等文本分区转换为 App API 所需的数字值，并统一各排行接口的周期归一化。 ([#13](https://github.com/FlanChanXwO/javdb-cli/pull/13))
+
+## 新贡献者
+
+- [@kanoshiou](https://github.com/kanoshiou) 在 [#13](https://github.com/FlanChanXwO/javdb-cli/pull/13) 中完成首次贡献。
+
+**完整变更**：[v0.5.0...v0.5.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.5.0...v0.5.1)

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -109,6 +109,7 @@ Windows Git Bash runner 用预装 `7z` 生成 ZIP。
 4. `vX.Y.Z` tag 必须不可变且可追溯到 `main`；Release workflow 在打包前校验版本化双语 notes、
    审计来源，并以同一渲染正文创建 GitHub Release。
 5. 发布器核对资产、从同一 `checksums.txt` 渲染 Homebrew Formula，并在 macOS/Linux 的 amd64/arm64 环境验证。tap 部署是可选的：必须设置 `HOMEBREW_TAP_DEPLOY_ENABLED=true` 并在受保护 `release` environment 配置 `HOMEBREW_TAP_DEPLOY_KEY`；条件缺失时 Release 与 Formula 验证仍会完成。
+6. `.github/CODEOWNERS` 将默认 review 路由到唯一维护者；它只会为未来 PR 请求 reviewer，不能让 PR 作者批准自己的 PR，也不替代 `main` 的分支保护要求。
 
 历史 Release 回写、GitHub description 修改、release-prep PR 合并、创建 tag 与发布均是外部写入。
 在当前会话取得目标版本、范围和影响的明确授权后，先 dry-run，再使用 `sync-history --apply` 或


### PR DESCRIPTION
## Summary

- Prepare the audited bilingual release notes for v0.5.1.
- Record the audited user-visible changes delivered by #13 and #14.
- Record first-time contributor metadata for @kanoshiou.
- Remove the colon from the default `[Bug]` and `[Feature]` issue title prefixes.
- Route future pull-request review requests through `.github/CODEOWNERS` for the sole maintainer.

## Verification

```text
go test ./...
go test -race ./...
go vet ./...
sh scripts/build.sh
sh scripts/test-releasenotes.sh
sh scripts/test-package-release.sh
sh scripts/test-homebrew-formula.sh
sh scripts/test-workflows.sh
sh scripts/test-documentation.sh
sh scripts/test-architecture.sh
pre-commit run --all-files
ruby -rpsych -e "Psych.safe_load(File.read(path), permitted_classes: [], permitted_symbols: [], aliases: false)"
go run ./scripts/releasenotes audit --repo FlanChanXwO/javdb-cli --from v0.5.0 --to 191cc1e --require-classified --output /tmp/javdb-release-audit-v0.5.1.json
go run ./scripts/releasenotes validate --version 0.5.1 --previous v0.5.0 --dir changelog/v0.5.1 --audit /tmp/javdb-release-audit-v0.5.1.json
```

The local darwin/arm64 release rehearsal built `v0.5.1` and packaged `javdb-cli_0.5.1_darwin_arm64.tar.gz` successfully.

## Release note declaration

<!-- release-note
category: None
breaking: false
summary: Prepare the audited v0.5.1 changelog and maintainer review-routing cleanup.
none_reason: This release-prep PR records the audited outcomes of PRs #13 and #14; the issue-template punctuation cleanup, CODEOWNERS routing, and maintainer documentation are repository maintenance, do not change javdb-cli product behavior, and are intentionally excluded from versioned release notes.
-->