### PR TITLE
ci: publish javdb-cli skills to ClawHub and SkillHub

### DIFF
--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -1,0 +1,255 @@
+name: Publish ClawHub skill
+
+on:
+  # Release 只有在所有发布与 Homebrew gate 成功后才交接不可变 tag。
+  # GITHUB_TOKEN 创建的 Release 不会再触发第二个 release 事件，因此使用
+  # workflow_run 作为受信任的异步 handoff。
+  workflow_run:
+    workflows:
+      - Release
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing published immutable SemVer tag to publish to ClawHub
+        required: true
+        type: string
+      verify_only:
+        description: Verify an existing ClawHub version without publishing again
+        required: false
+        default: false
+        type: boolean
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Publish javdb-cli to ClawHub
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Download the trusted completed-release tag
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: skillhub-release-tag
+          path: ${{ runner.temp }}/skill-release-tag
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Resolve the immutable release tag
+        id: release_tag
+        shell: bash
+        env:
+          WORKFLOW_DISPATCH_RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" = workflow_dispatch ]; then
+            release_tag="$WORKFLOW_DISPATCH_RELEASE_TAG"
+          else
+            handoff_dir="$RUNNER_TEMP/skill-release-tag"
+            test "$(find "$handoff_dir" -maxdepth 1 -type f -print | LC_ALL=C sort)" = "$handoff_dir/release-tag"
+            release_tag=$(cat "$handoff_dir/release-tag")
+          fi
+          if ! printf '%s' "$release_tag" | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+            printf '%s\n' "release tag must be stable SemVer vX.Y.Z, got: $release_tag" >&2
+            exit 1
+          fi
+          printf 'value=%s\n' "$release_tag" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ steps.release_tag.outputs.value }}
+
+      - name: Verify immutable release and exact skill source
+        id: skill_change
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.release_tag.outputs.value }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git show-ref --verify --quiet "refs/tags/$RELEASE_TAG"
+          tag_commit=$(git rev-parse "$RELEASE_TAG^{commit}")
+          git show-ref --verify --quiet "refs/remotes/origin/$DEFAULT_BRANCH"
+          git merge-base --is-ancestor "$tag_commit" "origin/$DEFAULT_BRANCH"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq '.draft')" = false
+          test -n "$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq '.published_at')"
+          skill_version=$(sed -n 's/^version: //p' skills/javdb-cli/SKILL.md)
+          test "$(grep -c '^version: ' skills/javdb-cli/SKILL.md)" = 1
+          test "$skill_version" = "${RELEASE_TAG#v}"
+          git cat-file -e "$RELEASE_TAG:skills/javdb-cli/SKILL.md"
+          previous_tag=
+          while IFS= read -r tag; do
+            if [ "$tag" != "$RELEASE_TAG" ] &&
+              test -f "changelog/$tag/en.md" &&
+              test -f "changelog/$tag/zh-CN.md"; then
+              previous_tag=$tag
+              break
+            fi
+          done <<EOF
+          $(git tag --merged "$RELEASE_TAG" --list 'v[0-9]*' --sort=-v:refname)
+          EOF
+          if [ -z "$previous_tag" ]; then
+            printf 'publish=true\n' >> "$GITHUB_OUTPUT"
+          elif git diff --quiet "$previous_tag" "$RELEASE_TAG" -- skills/javdb-cli; then
+            printf 'publish=false\n' >> "$GITHUB_OUTPUT"
+            printf 'Skill unchanged since %s; skipping ClawHub publication.\n' "$previous_tag"
+          else
+            printf 'publish=true\n' >> "$GITHUB_OUTPUT"
+          fi
+          printf 'commit=%s\n' "$tag_commit" >> "$GITHUB_OUTPUT"
+          printf 'skill_version=%s\n' "$skill_version" >> "$GITHUB_OUTPUT"
+
+      - name: Install pinned ClawHub CLI without credentials
+        if: steps.skill_change.outputs.publish == 'true' || inputs.verify_only == true
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --global --ignore-scripts clawhub@0.23.1
+          test "$(clawhub --cli-version)" = 0.23.1
+
+      - name: Dry-run the exact tagged skill
+        id: dry_run
+        if: steps.skill_change.outputs.publish == 'true' || inputs.verify_only == true
+        shell: bash
+        env:
+          CLAWHUB_CONFIG_PATH: ${{ runner.temp }}/clawhub/config.json
+          RELEASE_TAG: ${{ steps.release_tag.outputs.value }}
+          RELEASE_COMMIT: ${{ steps.skill_change.outputs.commit }}
+          SKILL_VERSION: ${{ steps.skill_change.outputs.skill_version }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$(dirname "$CLAWHUB_CONFIG_PATH")"
+          clawhub skill publish skills/javdb-cli \
+            --version "$SKILL_VERSION" \
+            --source-repo "$GITHUB_REPOSITORY" \
+            --source-ref "$RELEASE_TAG" \
+            --source-commit "$RELEASE_COMMIT" \
+            --source-path skills/javdb-cli \
+            --dry-run \
+            --json > "$RUNNER_TEMP/clawhub-dry-run.json"
+          node - "$RUNNER_TEMP/clawhub-dry-run.json" "$SKILL_VERSION" "$GITHUB_OUTPUT" <<'NODE'
+          const fs = require("fs");
+          const [file, version, output] = process.argv.slice(2);
+          const result = JSON.parse(fs.readFileSync(file, "utf8"));
+          if (result.slug !== "javdb-cli" || result.version !== version || !/^[a-f0-9]{64}$/i.test(result.fingerprint)) {
+            throw new Error("ClawHub dry-run did not produce the expected skill identity, version, and fingerprint");
+          }
+          fs.appendFileSync(output, "fingerprint=" + result.fingerprint + "\n");
+          NODE
+
+      # ClawHub 的安全汇总可能异步完成；该恢复路径只验证已有版本，绝不重发。
+      - name: Verify an already-published ClawHub skill
+        if: inputs.verify_only == true
+        shell: bash
+        env:
+          CLAWHUB_CONFIG_PATH: ${{ runner.temp }}/clawhub/config.json
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+          SKILL_VERSION: ${{ steps.skill_change.outputs.skill_version }}
+          EXPECTED_FINGERPRINT: ${{ steps.dry_run.outputs.fingerprint }}
+        run: |
+          set -euo pipefail
+          test -n "$CLAWHUB_TOKEN"
+          mkdir -p "$(dirname "$CLAWHUB_CONFIG_PATH")"
+          clawhub --no-input login --token "$CLAWHUB_TOKEN"
+          verify_exit=0
+          clawhub skill verify javdb-cli --version "$SKILL_VERSION" > "$RUNNER_TEMP/clawhub-verify.json" || verify_exit=$?
+          node - "$RUNNER_TEMP/clawhub-verify.json" "$SKILL_VERSION" "$EXPECTED_FINGERPRINT" "$verify_exit" <<'NODE'
+          const fs = require("fs");
+          const [verifyFile, version, fingerprint, exitCode] = process.argv.slice(2);
+          const verify = JSON.parse(fs.readFileSync(verifyFile, "utf8"));
+          const identityMatches = verify.schema === "clawhub.skill.verify.v1" && verify.slug === "javdb-cli" && verify.version === version && verify.resolvedFrom === "version";
+          const artifactMatches = verify.artifact?.sourceFingerprint === fingerprint;
+          const securityIsClean = verify.security?.passed === true && verify.security?.status === "clean";
+          const cardPendingOnly = verify.ok === false && verify.decision === "fail" && verify.reasons?.length === 1 && verify.reasons[0] === "card.missing";
+          const passed = verify.ok === true && verify.decision === "pass" && Array.isArray(verify.reasons) && verify.reasons.length === 0;
+          if (!identityMatches || !artifactMatches || !securityIsClean || (!passed && !cardPendingOnly) || (passed && exitCode !== "0") || (cardPendingOnly && exitCode !== "1")) {
+            console.error(JSON.stringify(verify, null, 2));
+            throw new Error("ClawHub verification did not establish the immutable published artifact");
+          }
+          if (cardPendingOnly) {
+            console.warn("::warning title=ClawHub skill card pending::The published artifact and security scan are verified, but ClawHub has not generated its asynchronous skill-card.md yet.");
+          }
+          NODE
+
+      - name: Publish and inspect ClawHub skill
+        if: steps.skill_change.outputs.publish == 'true' && inputs.verify_only != true
+        shell: bash
+        env:
+          CLAWHUB_CONFIG_PATH: ${{ runner.temp }}/clawhub/config.json
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.release_tag.outputs.value }}
+          RELEASE_COMMIT: ${{ steps.skill_change.outputs.commit }}
+          SKILL_VERSION: ${{ steps.skill_change.outputs.skill_version }}
+          EXPECTED_FINGERPRINT: ${{ steps.dry_run.outputs.fingerprint }}
+        run: |
+          set -euo pipefail
+          test -n "$CLAWHUB_TOKEN"
+          mkdir -p "$(dirname "$CLAWHUB_CONFIG_PATH")"
+          clawhub --no-input login --token "$CLAWHUB_TOKEN"
+          clawhub skill publish skills/javdb-cli \
+            --version "$SKILL_VERSION" \
+            --source-repo "$GITHUB_REPOSITORY" \
+            --source-ref "$RELEASE_TAG" \
+            --source-commit "$RELEASE_COMMIT" \
+            --source-path skills/javdb-cli \
+            --json > "$RUNNER_TEMP/clawhub-publish.json"
+          verify_exit=0
+          clawhub skill verify javdb-cli --version "$SKILL_VERSION" > "$RUNNER_TEMP/clawhub-verify.json" || verify_exit=$?
+          node - "$RUNNER_TEMP/clawhub-publish.json" "$RUNNER_TEMP/clawhub-verify.json" "$SKILL_VERSION" "$EXPECTED_FINGERPRINT" "$verify_exit" <<'NODE'
+          const fs = require("fs");
+          const [publishFile, verifyFile, version, fingerprint, exitCode] = process.argv.slice(2);
+          const publish = JSON.parse(fs.readFileSync(publishFile, "utf8"));
+          const verify = JSON.parse(fs.readFileSync(verifyFile, "utf8"));
+          if (publish.slug !== "javdb-cli" || publish.version !== version || publish.fingerprint !== fingerprint) {
+            throw new Error("ClawHub publish response omitted the expected identity, version, or fingerprint");
+          }
+          const identityMatches = verify.schema === "clawhub.skill.verify.v1" && verify.slug === "javdb-cli" && verify.version === version && verify.resolvedFrom === "version";
+          const artifactMatches = verify.artifact?.sourceFingerprint === fingerprint;
+          const securityIsClean = verify.security?.passed === true && verify.security?.status === "clean";
+          const staticScanClean = verify.security?.signals?.staticScan?.status === "clean";
+          const aggregateSecurityPending = verify.security?.passed === false && verify.security?.status === "pending";
+          const cardPendingOnly = !aggregateSecurityPending && verify.ok === false && verify.decision === "fail" && verify.reasons?.length === 1 && verify.reasons[0] === "card.missing";
+          const pendingReasonCodes = new Set(["card.missing", "security.status_not_clean", "security.pending"]);
+          const pendingAggregationOnly = verify.ok === false && verify.decision === "fail" && Array.isArray(verify.reasons) && verify.reasons.length > 0 && verify.reasons.every((reason) => pendingReasonCodes.has(reason)) && staticScanClean && aggregateSecurityPending;
+          const passed = verify.ok === true && verify.decision === "pass" && Array.isArray(verify.reasons) && verify.reasons.length === 0;
+          const rejectVerification = () => {
+            console.error(JSON.stringify(verify, null, 2));
+            throw new Error("ClawHub verification did not establish the immutable published artifact");
+          };
+          if (!identityMatches || !artifactMatches) {
+            rejectVerification();
+          }
+          if (passed) {
+            if (!securityIsClean || exitCode !== "0") {
+              rejectVerification();
+            }
+          } else if (cardPendingOnly) {
+            if (!securityIsClean || exitCode !== "1") {
+              rejectVerification();
+            }
+          } else if (pendingAggregationOnly) {
+            if (exitCode !== "1") {
+              rejectVerification();
+            }
+          } else {
+            rejectVerification();
+          }
+          if (cardPendingOnly) {
+            console.warn("::warning title=ClawHub skill card pending::The published artifact and security scan are verified, but ClawHub has not generated its asynchronous skill-card.md yet.");
+          }
+          if (pendingAggregationOnly) {
+            console.warn("::warning title=ClawHub aggregate security scan pending::The published artifact and ClawHub static scan are verified, but the platform has not completed its aggregate security decision. Run verify_only later; it requires a clean completed scan.");
+          }
+          NODE

--- a/.github/workflows/publish-skillhub.yml
+++ b/.github/workflows/publish-skillhub.yml
@@ -1,0 +1,167 @@
+name: Publish SkillHub skill
+
+on:
+  # Release 成功后从同一 run 的 handoff artifact 获取不可变 tag。
+  # 不根据 workflow_run 的 head branch 推断版本；恢复发布时它可能是 main。
+  workflow_run:
+    workflows:
+      - Release
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing published immutable SemVer tag to publish to SkillHub
+        required: true
+        type: string
+
+env:
+  SKILLHUB_HOST: https://api.skillhub.cn
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Publish javdb-cli to SkillHub
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Download the trusted completed-release tag
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: skillhub-release-tag
+          path: ${{ runner.temp }}/skillhub-release-tag
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Resolve the immutable release tag
+        id: release_tag
+        shell: bash
+        env:
+          WORKFLOW_DISPATCH_RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" = workflow_dispatch ]; then
+            release_tag="$WORKFLOW_DISPATCH_RELEASE_TAG"
+          else
+            handoff_dir="$RUNNER_TEMP/skillhub-release-tag"
+            test "$(find "$handoff_dir" -maxdepth 1 -type f -print | LC_ALL=C sort)" = "$handoff_dir/release-tag"
+            release_tag=$(cat "$handoff_dir/release-tag")
+          fi
+          if ! printf '%s' "$release_tag" | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+            printf '%s\n' "release tag must be stable SemVer vX.Y.Z, got: $release_tag" >&2
+            exit 1
+          fi
+          printf 'value=%s\n' "$release_tag" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ steps.release_tag.outputs.value }}
+
+      - name: Verify the published release tag and exact skill source
+        id: skill_change
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.release_tag.outputs.value }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git show-ref --verify --quiet "refs/tags/$RELEASE_TAG"
+          tag_commit=$(git rev-parse "$RELEASE_TAG^{commit}")
+          git show-ref --verify --quiet "refs/remotes/origin/$DEFAULT_BRANCH"
+          git merge-base --is-ancestor "$tag_commit" "origin/$DEFAULT_BRANCH"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq '.draft')" = false
+          test -n "$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq '.published_at')"
+          skill_version=$(sed -n 's/^version: //p' skills/javdb-cli/SKILL.md)
+          test "$(grep -c '^version: ' skills/javdb-cli/SKILL.md)" = 1
+          test "$skill_version" = "${RELEASE_TAG#v}"
+          git cat-file -e "$RELEASE_TAG:skills/javdb-cli/SKILL.md"
+          test -f "changelog/$RELEASE_TAG/en.md"
+          test -f "changelog/$RELEASE_TAG/zh-CN.md"
+          previous_tag=
+          while IFS= read -r tag; do
+            if [ "$tag" != "$RELEASE_TAG" ] &&
+              test -f "changelog/$tag/en.md" &&
+              test -f "changelog/$tag/zh-CN.md"; then
+              previous_tag=$tag
+              break
+            fi
+          done <<EOF
+          $(git tag --merged "$RELEASE_TAG" --list 'v[0-9]*' --sort=-v:refname)
+          EOF
+          if [ -z "$previous_tag" ]; then
+            printf 'publish=true\n' >> "$GITHUB_OUTPUT"
+          elif git diff --quiet "$previous_tag" "$RELEASE_TAG" -- skills/javdb-cli; then
+            printf 'publish=false\n' >> "$GITHUB_OUTPUT"
+            printf 'Skill unchanged since %s; skipping SkillHub publication.\n' "$previous_tag"
+          else
+            printf 'publish=true\n' >> "$GITHUB_OUTPUT"
+          fi
+          printf 'commit=%s\n' "$tag_commit" >> "$GITHUB_OUTPUT"
+
+      # 官方 installer 在 token 注入前执行；dry-run 只做本地 metadata/打包检查。
+      - name: Install the official SkillHub CLI without credentials
+        if: steps.skill_change.outputs.publish == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          installer="$RUNNER_TEMP/skillhub-install.sh"
+          curl --fail --location --silent --show-error https://skillhub.cn/install/install.sh --output "$installer"
+          bash "$installer" --cli-only
+          "$HOME/.local/bin/skillhub" --skip-self-upgrade --version
+
+      - name: Dry-run the exact tagged skill
+        if: steps.skill_change.outputs.publish == 'true'
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.release_tag.outputs.value }}
+        run: |
+          set -euo pipefail
+          "$HOME/.local/bin/skillhub" --skip-self-upgrade publish skills/javdb-cli \
+            --host "$SKILLHUB_HOST" \
+            --version "${RELEASE_TAG#v}" \
+            --dry-run \
+            --json
+
+      - name: Publish and confirm the SkillHub submission
+        if: steps.skill_change.outputs.publish == 'true'
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.release_tag.outputs.value }}
+          SKILLHUB_TOKEN: ${{ secrets.SKILLHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          test -n "$SKILLHUB_TOKEN"
+          response="$RUNNER_TEMP/skillhub-publish.json"
+          "$HOME/.local/bin/skillhub" --skip-self-upgrade publish skills/javdb-cli \
+            --host "$SKILLHUB_HOST" \
+            --version "${RELEASE_TAG#v}" \
+            --changelog "Synchronized with javdb-cli $RELEASE_TAG" \
+            --json | tee "$response"
+          python3 - "$response" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as source:
+              result = json.load(source)
+
+          skill_id = result.get("skillId")
+          review_status = result.get("reviewStatus") or result.get("status")
+          if result.get("ok") is not True or not skill_id or not review_status:
+              raise SystemExit("SkillHub accepted the request without skillId or review status")
+
+          print(f"SkillHub submission confirmed: skillId={skill_id} reviewStatus={review_status}")
+          public_url = result.get("publicUrl")
+          if public_url:
+              print(f"SkillHub URL: {public_url}")
+          PY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -437,6 +437,22 @@ jobs:
           fi
           gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false
 
+      # 下游 skill 发布 workflow 只信任这个由已公开 Release 生成的 tag handoff；
+      # 不从 workflow_run 的 head_branch 推断版本，也不重新读取 main。
+      - name: Hand off the immutable release tag to skill publishers
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p skillhub-release-tag
+          printf '%s\n' "$RELEASE_TAG" > skillhub-release-tag/release-tag
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: skillhub-release-tag
+          path: skillhub-release-tag/release-tag
+          if-no-files-found: error
+          retention-days: 1
+
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: verified-release-checksums

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@ grouped by user outcome and carry inline PR or historical direct-commit sources;
 | Version | Date | Release notes |
 | --- | --- | --- |
 | Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
+| [v0.5.2](https://github.com/FlanChanXwO/javdb-cli/compare/v0.5.1...v0.5.2) | 2026-08-09 | [English](v0.5.2/en.md) · [简体中文](v0.5.2/zh-CN.md) |
 | [v0.5.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.5.0...v0.5.1) | 2026-08-09 | [English](v0.5.1/en.md) · [简体中文](v0.5.1/zh-CN.md) |
 | [v0.5.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.4.0...v0.5.0) | 2026-08-05 | [English](v0.5.0/en.md) · [简体中文](v0.5.0/zh-CN.md) |
 | [v0.4.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.3.0...v0.4.0) | 2026-08-05 | [English](v0.4.0/en.md) · [简体中文](v0.4.0/zh-CN.md) |

--- a/changelog/README.zh-CN.md
+++ b/changelog/README.zh-CN.md
@@ -5,6 +5,7 @@
 | 版本 | 日期 | 发布说明 |
 | --- | --- | --- |
 | Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
+| [v0.5.2](https://github.com/FlanChanXwO/javdb-cli/compare/v0.5.1...v0.5.2) | 2026-08-09 | [English](v0.5.2/en.md) · [简体中文](v0.5.2/zh-CN.md) |
 | [v0.5.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.5.0...v0.5.1) | 2026-08-09 | [English](v0.5.1/en.md) · [简体中文](v0.5.1/zh-CN.md) |
 | [v0.5.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.4.0...v0.5.0) | 2026-08-05 | [English](v0.5.0/en.md) · [简体中文](v0.5.0/zh-CN.md) |
 | [v0.4.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.3.0...v0.4.0) | 2026-08-05 | [English](v0.4.0/en.md) · [简体中文](v0.4.0/zh-CN.md) |

--- a/changelog/plans/v0.5.2.json
+++ b/changelog/plans/v0.5.2.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.5.2",
+  "previous_tag": "v0.5.1",
+  "compare_url": "https://github.com/FlanChanXwO/javdb-cli/compare/v0.5.1...v0.5.2",
+  "entries": [
+    {
+      "category": "Added",
+      "breaking": false,
+      "english": "Add versioned `javdb-cli` Agent skill distribution to SkillHub and ClawHub with immutable tag verification and credential-free dry-runs before publication.",
+      "zh_cn": "新增按版本发布 `javdb-cli` Agent skill 到 SkillHub 与 ClawHub，并在发布前校验不可变 tag、使用无凭据 dry-run。",
+      "sources": [
+        "https://github.com/FlanChanXwO/javdb-cli/pull/17"
+      ]
+    }
+  ],
+  "new_contributors": []
+}

--- a/changelog/v0.5.2/en.md
+++ b/changelog/v0.5.2/en.md
@@ -1,0 +1,7 @@
+# v0.5.2 — 2026-08-09
+
+## Added
+
+- Add versioned `javdb-cli` Agent skill distribution to SkillHub and ClawHub with immutable tag verification and credential-free dry-runs before publication. ([#17](https://github.com/FlanChanXwO/javdb-cli/pull/17))
+
+**Full Changelog**: [v0.5.1...v0.5.2](https://github.com/FlanChanXwO/javdb-cli/compare/v0.5.1...v0.5.2)

--- a/changelog/v0.5.2/zh-CN.md
+++ b/changelog/v0.5.2/zh-CN.md
@@ -1,0 +1,7 @@
+# v0.5.2 — 2026-08-09
+
+## 新增
+
+- 新增按版本发布 `javdb-cli` Agent skill 到 SkillHub 与 ClawHub，并在发布前校验不可变 tag、使用无凭据 dry-run。 ([#17](https://github.com/FlanChanXwO/javdb-cli/pull/17))
+
+**完整变更**：[v0.5.1...v0.5.2](https://github.com/FlanChanXwO/javdb-cli/compare/v0.5.1...v0.5.2)

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -110,6 +110,12 @@ Windows Git Bash runner 用预装 `7z` 生成 ZIP。
    审计来源，并以同一渲染正文创建 GitHub Release。
 5. 发布器核对资产、从同一 `checksums.txt` 渲染 Homebrew Formula，并在 macOS/Linux 的 amd64/arm64 环境验证。tap 部署是可选的：必须设置 `HOMEBREW_TAP_DEPLOY_ENABLED=true` 并在受保护 `release` environment 配置 `HOMEBREW_TAP_DEPLOY_KEY`；条件缺失时 Release 与 Formula 验证仍会完成。
 6. `.github/CODEOWNERS` 将默认 review 路由到唯一维护者；它只会为未来 PR 请求 reviewer，不能让 PR 作者批准自己的 PR，也不替代 `main` 的分支保护要求。
+7. Release 在公开 GitHub Release 后上传只含不可变 tag 的 `skillhub-release-tag` artifact。成功结束的
+   `Release` workflow 会由 `publish-clawhub.yml` 与 `publish-skillhub.yml` 通过 `workflow_run` 消费；
+   两者都 checkout 该 tag、验证它属于默认分支，并跳过未改变的 `skills/javdb-cli/`。ClawHub 使用锁定的
+   `clawhub@0.23.1` 先做无凭据 dry-run，再在最后发布步骤读取 `CLAWHUB_TOKEN`；SkillHub 同样先做
+   无凭据 dry-run，只有最终提交步骤读取 `SKILLHUB_TOKEN`。两个 token 只应配置为仓库或受保护
+   environment secret，绝不能写入 skill、workflow 日志或 Release notes。
 
 历史 Release 回写、GitHub description 修改、release-prep PR 合并、创建 tag 与发布均是外部写入。
 在当前会话取得目标版本、范围和影响的明确授权后，先 dry-run，再使用 `sync-history --apply` 或

--- a/scripts/test-skill-publish-workflows.sh
+++ b/scripts/test-skill-publish-workflows.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# 检查 ClawHub/SkillHub 发布 workflow 的信任边界与 token 最小暴露范围。
+set -eu
+
+script_dir=$(dirname -- "$0")
+repo_root=$(CDPATH=; cd -- "$script_dir/.." && pwd)
+workflow_dir="$repo_root/.github/workflows"
+clawhub_workflow="$workflow_dir/publish-clawhub.yml"
+skillhub_workflow="$workflow_dir/publish-skillhub.yml"
+release_workflow="$workflow_dir/release.yml"
+skill="$repo_root/skills/javdb-cli/SKILL.md"
+github_expr='$'
+
+for workflow in "$clawhub_workflow" "$skillhub_workflow" "$release_workflow"; do
+	ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' "$workflow"
+done
+
+ruby - "$clawhub_workflow" "$skillhub_workflow" "$release_workflow" <<'RUBY'
+pattern = %r{\Aactions/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?@[0-9a-f]{40}\z}
+ARGV.each do |path|
+  File.foreach(path).with_index(1) do |line, number|
+    next unless line =~ /^\s*-\s+uses:\s+(\S+)/
+    reference = Regexp.last_match(1)
+    next unless reference.start_with?("actions/")
+    abort("#{path}:#{number}: action is not pinned to a full commit SHA: #{reference}") unless pattern.match?(reference)
+  end
+end
+RUBY
+
+for workflow in "$clawhub_workflow" "$skillhub_workflow"; do
+	grep -F 'workflow_run:' "$workflow" >/dev/null
+	grep -F -- '- Release' "$workflow" >/dev/null
+	grep -F 'types:' "$workflow" >/dev/null
+	grep -F 'permissions: {}' "$workflow" >/dev/null
+	grep -F 'actions: read' "$workflow" >/dev/null
+	grep -F 'contents: read' "$workflow" >/dev/null
+	grep -F 'name: skillhub-release-tag' "$workflow" >/dev/null
+	grep -F 'git merge-base --is-ancestor' "$workflow" >/dev/null
+	grep -F "releases/tags/\$RELEASE_TAG" "$workflow" >/dev/null
+	grep -F "ref: $github_expr{{ steps.release_tag.outputs.value }}" "$workflow" >/dev/null
+done
+
+grep -F 'clawhub@0.23.1' "$clawhub_workflow" >/dev/null
+grep -F 'clawhub skill publish skills/javdb-cli' "$clawhub_workflow" >/dev/null
+grep -F -- "--source-commit \"\$RELEASE_COMMIT\"" "$clawhub_workflow" >/dev/null
+grep -F "CLAWHUB_TOKEN: $github_expr{{ secrets.CLAWHUB_TOKEN }}" "$clawhub_workflow" >/dev/null
+grep -F -- '--dry-run' "$clawhub_workflow" >/dev/null
+
+grep -F 'SKILLHUB_HOST: https://api.skillhub.cn' "$skillhub_workflow" >/dev/null
+grep -F -- '--skip-self-upgrade publish skills/javdb-cli' "$skillhub_workflow" >/dev/null
+grep -F "SKILLHUB_TOKEN: $github_expr{{ secrets.SKILLHUB_TOKEN }}" "$skillhub_workflow" >/dev/null
+grep -F -- '--dry-run' "$skillhub_workflow" >/dev/null
+
+test "$(grep -c "CLAWHUB_TOKEN: $github_expr{{ secrets.CLAWHUB_TOKEN }}" "$clawhub_workflow")" = 2
+test "$(grep -c "SKILLHUB_TOKEN: $github_expr{{ secrets.SKILLHUB_TOKEN }}" "$skillhub_workflow")" = 1
+grep -F 'name: Hand off the immutable release tag to skill publishers' "$release_workflow" >/dev/null
+grep -F 'skillhub-release-tag/release-tag' "$release_workflow" >/dev/null
+
+for field in slug version displayName summary license homepage tags name description; do
+	grep -Eq "^$field: " "$skill" || {
+		printf '%s\n' "skill metadata field missing: $field" >&2
+		exit 1
+	}
+done

--- a/scripts/test-workflows.sh
+++ b/scripts/test-workflows.sh
@@ -8,7 +8,9 @@ for workflow in \
 	"$repo_root/.github/workflows/ci.yml" \
 	"$repo_root/.github/workflows/platform-smoke.yml" \
 	"$repo_root/.github/workflows/release.yml" \
-	"$repo_root/.github/workflows/e2e.yml"; do
+	"$repo_root/.github/workflows/e2e.yml" \
+	"$repo_root/.github/workflows/publish-clawhub.yml" \
+	"$repo_root/.github/workflows/publish-skillhub.yml"; do
 	ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' "$workflow"
 done
 
@@ -34,6 +36,7 @@ grep -F 'scripts/releasenotes render' "$release_workflow" >/dev/null
 grep -F -- '--notes-file release/release-notes.md' "$release_workflow" >/dev/null
 grep -F 'gh release create "$RELEASE_TAG"' "$release_workflow" >/dev/null
 grep -F 'HOMEBREW_TAP_DEPLOY_ENABLED' "$release_workflow" >/dev/null
+sh "$repo_root/scripts/test-skill-publish-workflows.sh"
 
 # 文档专属路径必须有一致的 classifier 与稳定汇总 gate；workflow 本身的改动不在白名单内。
 for workflow in "$quality_workflow" "$platform_workflow"; do

--- a/skills/javdb-cli/SKILL.md
+++ b/skills/javdb-cli/SKILL.md
@@ -1,4 +1,11 @@
 ---
+slug: javdb-cli
+version: 0.5.2
+displayName: JavDB CLI
+summary: Safely operate JavDB through the javdb-cli binary for discovery, authenticated lists, and explicit state changes.
+license: MIT
+homepage: https://github.com/FlanChanXwO/javdb-cli
+tags: [javdb, cli, agent]
 name: javdb-cli
 description: 通过 javdb-cli 的 `javdb` 二进制检索 JavDB App API 的影片、人物、标签、榜单与合集，并在用户明确授权时管理账号、配置和观看标记。仅当用户明确提到 JavDB、javdb-cli、`javdb` 命令，或提供明显的 JavDB 编号/链接并要求操作时加载；不要用于泛搜索、泛成人内容或下载请求。每次执行前以 `javdb <command> --help` 核对当前可用参数。
 ---


### PR DESCRIPTION
## Summary / 概述

- Add registry metadata and version `0.5.2` to `skills/javdb-cli/SKILL.md`.
- Add trusted, immutable-tag handoff from the Release workflow to independent ClawHub and SkillHub publishers.
- Run credential-free dry-runs before the final token-bearing publication step and verify the published artifact identity.
- Add static workflow checks covering permissions, pinned Actions, release ancestry, metadata, and token exposure.
- Keep README registry links for the follow-up after both public skill submissions succeed.

## Scope and compatibility / 范围与兼容性

- Affects the operator skill metadata, release workflow, release maintainer documentation, and repository secrets `CLAWHUB_TOKEN` and `SKILLHUB_TOKEN`.
- There is no CLI command, public Go SDK, or API behavior change. `javdb-cli` has no MCP server.
- The two tokens must remain repository or protected-environment secrets; no token is placed in the skill, workflow source, logs, or release notes.

## Verification / 验证

```text
go test ./...                         # passed
sh scripts/build.sh                   # passed
sh scripts/test-workflows.sh          # passed
sh scripts/test-documentation.sh      # passed
shellcheck scripts/test-skill-publish-workflows.sh  # passed
git diff --check                      # passed
clawhub skill publish ... --dry-run --json  # passed; javdb-cli@0.5.2 fingerprint generated
skillhub ... publish ... --dry-run --json    # passed; javdb-cli@0.5.2 recognized
```

No real JavDB App API coverage was run; this change does not alter the API client.

## Release note declaration / Release note 声明

<!-- release-note
category: Added
breaking: false
summary: Add versioned javdb-cli Agent skill distribution to SkillHub and ClawHub with immutable tag verification and credential-free dry-runs before publication.
none_reason:
-->

## Checklist / 检查清单

- [x] The change is focused and linked to an issue when appropriate. / 改动目标明确，并在适用时关联 Issue。
- [x] I added or updated focused tests for changed behavior. / 我已为变更行为新增或更新聚焦测试。
- [x] I ran the relevant tests and recorded the results above. / 我已运行相关测试并在上方记录结果。
- [x] I updated the required maintainer and operator-skill documentation. README registry links are intentionally a post-publication follow-up. / 我已更新所需的维护者与 operator-skill 文档；README 社区链接会在发布成功后补充。
- [x] I completed the required release-note declaration above; `None` has a concrete reason when selected. / 我已填写上方必需的 release-note 声明；选择 `None` 时已提供具体理由。
- [x] I documented every new timeout, retry, pagination or result limit, truncation, fallback, or downgrade and its evidence. / 我已记录每项新增 timeout、retry、pagination 或结果限制、truncation、fallback 或 downgrade 及其证据。
- [x] I did not add passwords, JWTs, `~/.javdb-cli/auth.json` contents, proxy credentials, private URLs, local state, or private API responses. / 我没有添加密码、JWT、`~/.javdb-cli/auth.json` 内容、代理凭据、私有 URL、本地状态或私有 API 响应。
- [x] I updated migration guidance for every breaking change. / 我已为每个破坏性变更更新迁移指引。

## Summary by Sourcery

添加版本化的 `javdb-cli` 技能元数据，并引入基于标签的安全工作流，将技能发布到 ClawHub 和 SkillHub，同时在令牌使用和制品验证方面设置防护栏。

New Features:
- 定义 `javdb-cli` 技能注册表元数据，包括 slug、版本 `0.5.2`、显示名称、摘要、许可证、主页以及标签（tags）。
- 新增 ClawHub 和 SkillHub 发布工作流，消费不可变的发布标签，并支持手动触发以用于恢复或验证。

Enhancements:
- 扩展发布工作流，生成包含不可变发布标签的可信制品，供下游技能发布流程使用。
- 在维护者开发文档中记录新的技能发布流程以及令牌处理要求。
- 添加静态测试脚本，用于强制执行工作流信任边界、固定 Actions 版本、发布谱系检查，以及尽量减少注册表令牌的暴露。
- 更新工作流测试覆盖范围，将新的 ClawHub 和 SkillHub 发布工作流纳入测试。

Tests:
- 引入针对 ClawHub 和 SkillHub 工作流的自动化检查，确保使用已固定版本的 actions、正确的权限设置、不可变标签传递，以及必需技能元数据字段的存在。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add versioned javdb-cli skill metadata and introduce secure, tag-based workflows to publish the skill to ClawHub and SkillHub with guardrails around tokens and artifact verification.

New Features:
- Define javdb-cli skill registry metadata including slug, version 0.5.2, display name, summary, license, homepage, and tags.
- Add ClawHub and SkillHub publishing workflows that consume the immutable release tag and support manual dispatch for recovery or verification.

Enhancements:
- Extend the release workflow to emit a trusted artifact containing the immutable release tag for downstream skill publishers.
- Document the new skill publishing flows and token handling requirements in maintainer development docs.
- Add a static test script to enforce workflow trust boundaries, pinned Actions, release ancestry, and minimum exposure of registry tokens.
- Update workflow test coverage to include the new ClawHub and SkillHub publish workflows.

Tests:
- Introduce automated checks for ClawHub and SkillHub workflows to ensure use of pinned actions, correct permissions, immutable tag handoff, and required skill metadata fields.

</details>