### PR TITLE
fix(ci): verify ClawHub skills through public endpoint

### DIFF
--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -155,16 +155,17 @@ jobs:
         shell: bash
         env:
           CLAWHUB_CONFIG_PATH: ${{ runner.temp }}/clawhub/config.json
-          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
           SKILL_VERSION: ${{ steps.skill_change.outputs.skill_version }}
           EXPECTED_FINGERPRINT: ${{ steps.dry_run.outputs.fingerprint }}
         run: |
           set -euo pipefail
-          test -n "$CLAWHUB_TOKEN"
-          mkdir -p "$(dirname "$CLAWHUB_CONFIG_PATH")"
-          clawhub --no-input login --token "$CLAWHUB_TOKEN"
+          public_config_path="$RUNNER_TEMP/clawhub-public/config.json"
+          mkdir -p "$(dirname "$public_config_path")"
           verify_exit=0
-          clawhub skill verify javdb-cli --version "$SKILL_VERSION" > "$RUNNER_TEMP/clawhub-verify.json" || verify_exit=$?
+          # 发布后强制从无凭据的公开端点核验；带 publisher token 时，ClawHub
+          # 可能在异步 moderation 期间返回非 JSON 的隐藏提示，而不是公开版本证据。
+          env -u CLAWHUB_TOKEN CLAWHUB_CONFIG_PATH="$public_config_path" \
+            clawhub skill verify javdb-cli --version "$SKILL_VERSION" > "$RUNNER_TEMP/clawhub-verify.json" || verify_exit=$?
           node - "$RUNNER_TEMP/clawhub-verify.json" "$SKILL_VERSION" "$EXPECTED_FINGERPRINT" "$verify_exit" <<'NODE'
           const fs = require("fs");
           const [verifyFile, version, fingerprint, exitCode] = process.argv.slice(2);
@@ -205,8 +206,13 @@ jobs:
             --source-commit "$RELEASE_COMMIT" \
             --source-path skills/javdb-cli \
             --json > "$RUNNER_TEMP/clawhub-publish.json"
+          public_config_path="$RUNNER_TEMP/clawhub-public/config.json"
+          mkdir -p "$(dirname "$public_config_path")"
           verify_exit=0
-          clawhub skill verify javdb-cli --version "$SKILL_VERSION" > "$RUNNER_TEMP/clawhub-verify.json" || verify_exit=$?
+          # 发布后强制从无凭据的公开端点核验；带 publisher token 时，ClawHub
+          # 可能在异步 moderation 期间返回非 JSON 的隐藏提示，而不是公开版本证据。
+          env -u CLAWHUB_TOKEN CLAWHUB_CONFIG_PATH="$public_config_path" \
+            clawhub skill verify javdb-cli --version "$SKILL_VERSION" > "$RUNNER_TEMP/clawhub-verify.json" || verify_exit=$?
           node - "$RUNNER_TEMP/clawhub-publish.json" "$RUNNER_TEMP/clawhub-verify.json" "$SKILL_VERSION" "$EXPECTED_FINGERPRINT" "$verify_exit" <<'NODE'
           const fs = require("fs");
           const [publishFile, verifyFile, version, fingerprint, exitCode] = process.argv.slice(2);

--- a/scripts/test-skill-publish-workflows.sh
+++ b/scripts/test-skill-publish-workflows.sh
@@ -51,7 +51,8 @@ grep -F -- '--skip-self-upgrade publish skills/javdb-cli' "$skillhub_workflow" >
 grep -F "SKILLHUB_TOKEN: $github_expr{{ secrets.SKILLHUB_TOKEN }}" "$skillhub_workflow" >/dev/null
 grep -F -- '--dry-run' "$skillhub_workflow" >/dev/null
 
-test "$(grep -c "CLAWHUB_TOKEN: $github_expr{{ secrets.CLAWHUB_TOKEN }}" "$clawhub_workflow")" = 2
+test "$(grep -c "CLAWHUB_TOKEN: $github_expr{{ secrets.CLAWHUB_TOKEN }}" "$clawhub_workflow")" = 1
+test "$(grep -c "env -u CLAWHUB_TOKEN CLAWHUB_CONFIG_PATH=\"\$public_config_path\"" "$clawhub_workflow")" = 2
 test "$(grep -c "SKILLHUB_TOKEN: $github_expr{{ secrets.SKILLHUB_TOKEN }}" "$skillhub_workflow")" = 1
 grep -F 'name: Hand off the immutable release tag to skill publishers' "$release_workflow" >/dev/null
 grep -F 'skillhub-release-tag/release-tag' "$release_workflow" >/dev/null


### PR DESCRIPTION
## Summary / 概述

- Fix the ClawHub post-publication verification path to use the public, unauthenticated verify endpoint.
- Keep `CLAWHUB_TOKEN` limited to the actual publish step; `verify_only` no longer needs credentials.
- Preserve fingerprint, version, artifact, security, and asynchronous `card.missing` assertions.

This fixes PR #17's ClawHub run. The v0.5.2 publication itself succeeded; the old workflow failed because the authenticated verify call returned ClawHub's temporary moderation text instead of JSON.

## Scope and compatibility / 范围与兼容性

- CI/workflow behavior only; no CLI, SDK, skill content, or release tag changes.
- The existing public `javdb-cli@0.5.2` ClawHub artifact is verified by fingerprint and security evidence; this PR does not republish it.
- `javdb-cli` has no MCP server.

## Verification / 验证

```text
sh scripts/test-skill-publish-workflows.sh  # passed
sh scripts/test-workflows.sh                # passed
sh scripts/test-documentation.sh            # passed
shellcheck scripts/test-skill-publish-workflows.sh  # passed
git diff --check                            # passed
env -u CLAWHUB_TOKEN CLAWHUB_CONFIG_PATH=... clawhub skill verify javdb-cli --version 0.5.2  # passed expected public evidence; card.missing only
```

## Release note declaration / Release note 声明

<!-- release-note
category: Maintenance
breaking: false
summary: Fix ClawHub post-publication verification to validate the public skill endpoint without exposing publisher credentials during moderation.
none_reason:
-->

## Checklist / 检查清单

- [x] The change is focused and linked to an issue when appropriate. / 改动目标明确，并在适用时关联 Issue。
- [x] I added or updated focused tests for changed behavior. / 我已为变更行为新增或更新聚焦测试。
- [x] I ran the relevant tests and recorded the results above. / 我已运行相关测试并在上方记录结果。
- [x] I updated the required maintainer and operator-skill documentation. / 我已更新所需的维护者与 operator-skill 文档。
- [x] I completed the required release-note declaration above; `None` has a concrete reason when selected. / 我已填写上方必需的 release-note 声明；选择 `None` 时已提供具体理由。
- [x] I documented every new timeout, retry, pagination or result limit, truncation, fallback, or downgrade and its evidence. / 我已记录每项新增 timeout、retry、pagination 或结果限制、truncation、fallback 或 downgrade 及其证据。
- [x] I did not add passwords, JWTs, `~/.javdb-cli/auth.json` contents, proxy credentials, private URLs, local state, or private API responses. / 我没有添加密码、JWT、`~/.javdb-cli/auth.json` 内容、代理凭据、私有 URL、本地状态或私有 API 响应。
- [x] I updated migration guidance for every breaking change. / 我已为每个破坏性变更更新迁移指引。

## Summary by Sourcery

更新 ClawHub 发布工作流，使其改为针对公开的、无需认证的 skill 端点验证 javdb-cli 的发布，而不是使用需要发布者认证的 API。

Bug Fixes:
- 防止在已发布后，ClawHub 验证因在认证端点上出现经过审查的非 JSON 响应而失败。

CI:
- 将 `CLAWHUB_TOKEN` 的使用限制在发布步骤中，并在 ClawHub 工作流中引入无需凭证的验证配置。

Tests:
- 调整工作流测试，以断言减少的 `CLAWHUB_TOKEN` 使用以及基于环境变量的公开验证新行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update ClawHub publish workflow to verify javdb-cli releases against the public, unauthenticated skill endpoint instead of the publisher-authenticated API.

Bug Fixes:
- Prevent post-publication ClawHub verification from failing due to moderated, non-JSON responses on the authenticated endpoint.

CI:
- Limit use of CLAWHUB_TOKEN to the publish step and introduce a credential-free verification configuration in the ClawHub workflow.

Tests:
- Adjust workflow tests to assert the reduced CLAWHUB_TOKEN usage and the new env-based public verification behavior.

</details>