### PR TITLE
docs: document SkillHub and ClawHub skill installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,14 +193,15 @@ flags with `javdb <command> --help`.
 
 Agents with SkillHub support can install the published [`javdb-cli` Skill](https://www.skillhub.cn/skills/javdb-cli)
 directly from SkillHub. Each Skill version matches the `javdb-cli` release it
-teaches; always use `javdb <command> --help` as the final source of command
-syntax.
+teaches; the current published version is `0.5.2`. Always use
+`javdb <command> --help` as the final source of command syntax.
 
 ### Install the javdb-cli Skill from ClawHub
 
 Agents using ClawHub can install the published [`javdb-cli` Skill](https://clawhub.ai/flanchanxwo/skills/javdb-cli)
 with `clawhub install javdb-cli`; pin the installed skill to the matching
-published release version rather than following an unversioned `latest` tag.
+published release version, currently `0.5.2`, rather than following an
+unversioned `latest` tag.
 
 ## Authentication and credential safety
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,19 @@ boundaries, command-scoped flags, JSON/error handling, and search-to-detail
 navigation. Load it only for explicit JavDB work, and verify each command's
 flags with `javdb <command> --help`.
 
+### Install the javdb-cli Skill from SkillHub
+
+Agents with SkillHub support can install the published [`javdb-cli` Skill](https://www.skillhub.cn/skills/javdb-cli)
+directly from SkillHub. Each Skill version matches the `javdb-cli` release it
+teaches; always use `javdb <command> --help` as the final source of command
+syntax.
+
+### Install the javdb-cli Skill from ClawHub
+
+Agents using ClawHub can install the published [`javdb-cli` Skill](https://clawhub.ai/flanchanxwo/skills/javdb-cli)
+with `clawhub install javdb-cli`; pin the installed skill to the matching
+published release version rather than following an unversioned `latest` tag.
+
 ## Authentication and credential safety
 
 `javdb auth login` is the recommended setup. It keeps the username, password,

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -174,14 +174,14 @@ func main() {
 ### 从 SkillHub 安装 javdb-cli Skill
 
 支持 SkillHub 的 Agent 可以直接从 SkillHub 安装已发布的 [`javdb-cli` Skill](https://www.skillhub.cn/skills/javdb-cli)。
-每个 Skill 版本都对应它所教导的 `javdb-cli` 版本；命令语法最终应以
-`javdb <command> --help` 为准。
+每个 Skill 版本都对应它所教导的 `javdb-cli` 版本；当前已发布的版本为 `0.5.2`。
+命令语法最终应以 `javdb <command> --help` 为准。
 
 ### 从 ClawHub 安装 javdb-cli Skill
 
 使用 ClawHub 的 Agent 可以通过 `clawhub install javdb-cli` 安装已发布的
 [`javdb-cli` Skill](https://clawhub.ai/flanchanxwo/skills/javdb-cli)；请将已安装的 skill 固定到对应的
-published release 版本，不要跟随无版本的 `latest` tag。
+published release 版本（当前为 `0.5.2`），不要跟随无版本的 `latest` tag。
 
 ## 认证与凭据安全
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -171,6 +171,18 @@ func main() {
 它规定了凭据处理、确认边界、命令级参数、JSON/错误处理与搜索到详情的导航。仅在明确的 JavDB
 任务中加载，并在执行前用 `javdb <command> --help` 核对参数。
 
+### 从 SkillHub 安装 javdb-cli Skill
+
+支持 SkillHub 的 Agent 可以直接从 SkillHub 安装已发布的 [`javdb-cli` Skill](https://www.skillhub.cn/skills/javdb-cli)。
+每个 Skill 版本都对应它所教导的 `javdb-cli` 版本；命令语法最终应以
+`javdb <command> --help` 为准。
+
+### 从 ClawHub 安装 javdb-cli Skill
+
+使用 ClawHub 的 Agent 可以通过 `clawhub install javdb-cli` 安装已发布的
+[`javdb-cli` Skill](https://clawhub.ai/flanchanxwo/skills/javdb-cli)；请将已安装的 skill 固定到对应的
+published release 版本，不要跟随无版本的 `latest` tag。
+
 ## 认证与凭据安全
 
 推荐用 `javdb auth login` 配置账号。用户名、密码与 session token 会保存于本地多账号存储

--- a/scripts/test-documentation.sh
+++ b/scripts/test-documentation.sh
@@ -24,6 +24,10 @@ grep -F 'docs/en/cli-reference.md' "$repo_root/README.md" >/dev/null
 grep -F 'docs/en/sdk.md' "$repo_root/README.md" >/dev/null
 grep -F 'docs/zh-CN/cli-reference.md' "$repo_root/README.zh-CN.md" >/dev/null
 grep -F 'docs/zh-CN/sdk.md' "$repo_root/README.zh-CN.md" >/dev/null
+grep -F 'https://www.skillhub.cn/skills/javdb-cli' "$repo_root/README.md" >/dev/null
+grep -F 'https://clawhub.ai/flanchanxwo/skills/javdb-cli' "$repo_root/README.md" >/dev/null
+grep -F 'https://www.skillhub.cn/skills/javdb-cli' "$repo_root/README.zh-CN.md" >/dev/null
+grep -F 'https://clawhub.ai/flanchanxwo/skills/javdb-cli' "$repo_root/README.zh-CN.md" >/dev/null
 grep -F 'changelog/README.md' "$repo_root/CHANGELOG.md" >/dev/null
 grep -F 'changelog/README.zh-CN.md' "$repo_root/CHANGELOG.zh-CN.md" >/dev/null
 for document in \


### PR DESCRIPTION
## Summary

- document the public SkillHub installation page for the `javdb-cli` Agent skill
- document the public ClawHub installation page and version-pinning guidance
- add documentation tests for both registry links in both README locales

## Release-note declaration

<!-- release-note
category: Documentation
breaking: false
summary: Document SkillHub and ClawHub installation links for the javdb-cli Agent skill.
none_reason:
-->

## Validation

- `git diff --check`
- `sh scripts/test-documentation.sh`
- commit hook: `go test ./...`, release tooling, release notes, documentation structure, and architecture structure checks

The v0.5.2 GitHub Release and both registry publication paths were completed before this documentation follow-up. The README links point to the public SkillHub and ClawHub pages.
