### PR TITLE
docs(release): correct v0.6.0 notes

### DIFF
--- a/changelog/plans/v0.6.0.json
+++ b/changelog/plans/v0.6.0.json
@@ -23,15 +23,6 @@
       ]
     },
     {
-      "category": "Fixed",
-      "breaking": false,
-      "english": "Map textual rankings zones such as censored, uncensored, western and fc2 to App API numeric values, and normalize ranking periods consistently across endpoints.",
-      "zh_cn": "将 censored、uncensored、western、fc2 等排行榜文本分区映射为 App API 数字值，并统一各排行接口的周期归一化。",
-      "sources": [
-        "https://github.com/FlanChanXwO/javdb-cli/pull/13"
-      ]
-    },
-    {
       "category": "Maintenance",
       "breaking": false,
       "english": "Verify ClawHub publication through its public skill endpoint without exposing publisher credentials during moderation.",
@@ -50,12 +41,5 @@
       ]
     }
   ],
-  "new_contributors": [
-    {
-      "login": "kanoshiou",
-      "profile_url": "https://github.com/kanoshiou",
-      "pull_number": 13,
-      "pull_url": "https://github.com/FlanChanXwO/javdb-cli/pull/13"
-    }
-  ]
+  "new_contributors": []
 }

--- a/changelog/v0.6.0/en.md
+++ b/changelog/v0.6.0/en.md
@@ -8,17 +8,9 @@
 
 - Retire the SkillHub publisher, keep ClawHub as the active Agent skill distribution path, and document public ClawHub installation with version pinning. ([#19](https://github.com/FlanChanXwO/javdb-cli/pull/19), [#20](https://github.com/FlanChanXwO/javdb-cli/pull/20))
 
-## Fixed
-
-- Map textual rankings zones such as censored, uncensored, western and fc2 to App API numeric values, and normalize ranking periods consistently across endpoints. ([#13](https://github.com/FlanChanXwO/javdb-cli/pull/13))
-
 ## Maintenance
 
 - Verify ClawHub publication through its public skill endpoint without exposing publisher credentials during moderation. ([#18](https://github.com/FlanChanXwO/javdb-cli/pull/18))
 - Remove internal compatibility facades and realign the CLI around real commands; split app capabilities into invocation, client and authstore packages, and unify movie, magnet and named projections under result without changing public contracts. ([#21](https://github.com/FlanChanXwO/javdb-cli/pull/21))
-
-## New Contributors
-
-- [@kanoshiou](https://github.com/kanoshiou) made their first contribution in [#13](https://github.com/FlanChanXwO/javdb-cli/pull/13).
 
 **Full Changelog**: [v0.5.2...v0.6.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.5.2...v0.6.0)

--- a/changelog/v0.6.0/zh-CN.md
+++ b/changelog/v0.6.0/zh-CN.md
@@ -8,17 +8,9 @@
 
 - 退役 SkillHub 发布器，保留 ClawHub 作为当前 Agent skill 分发路径，并记录公开 ClawHub 安装与版本固定方法。 ([#19](https://github.com/FlanChanXwO/javdb-cli/pull/19), [#20](https://github.com/FlanChanXwO/javdb-cli/pull/20))
 
-## 修复
-
-- 将 censored、uncensored、western、fc2 等排行榜文本分区映射为 App API 数字值，并统一各排行接口的周期归一化。 ([#13](https://github.com/FlanChanXwO/javdb-cli/pull/13))
-
 ## 维护
 
 - 通过 ClawHub 的公开 skill endpoint 验证发布结果，避免在审核期间暴露发布凭据。 ([#18](https://github.com/FlanChanXwO/javdb-cli/pull/18))
 - 移除内部兼容 facade 并按真实命令重整 CLI；将 app 能力拆分为 invocation、client、authstore 包，并把 movie、magnet 与 named 投影统一到 result，保持公开契约不变。 ([#21](https://github.com/FlanChanXwO/javdb-cli/pull/21))
-
-## 新贡献者
-
-- [@kanoshiou](https://github.com/kanoshiou) 在 [#13](https://github.com/FlanChanXwO/javdb-cli/pull/13) 中完成首次贡献。
 
 **完整变更**：[v0.5.2...v0.6.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.5.2...v0.6.0)


### PR DESCRIPTION
## Summary / 概述

Correct the v0.6.0 bilingual release notes and plan by removing the rankings fix from #13 and the new-contributor entry for @kanoshiou. Both were already published in v0.5.1 and were duplicated because the release audit rediscovered an older PR inside the comparison history.

修正 v0.6.0 双语发布说明和计划，删除 #13 排行修复及 @kanoshiou 新贡献者条目；两者均已在 v0.5.1 发布，本次属于历史范围审计重复收录。

## Scope and compatibility / 范围与兼容性

Only `changelog/plans/v0.6.0.json` and the bilingual `changelog/v0.6.0/` documents are affected. No CLI, SDK, configuration, output, operator skill, tag, or release asset behavior changes.

仅影响 v0.6.0 的计划和双语 changelog。CLI、SDK、配置、输出、operator skill、tag 与 Release 资产均无变化。

## Verification / 验证

```text
go run ./scripts/releasenotes validate --version 0.6.0 --previous v0.5.2 --dir changelog/v0.6.0
sh scripts/test-releasenotes.sh
sh scripts/test-documentation.sh
git diff --check
pre-commit commit hooks: passed
```

The published GitHub Release body was separately synchronized to the corrected bilingual rendering; assets were unchanged.

## Release note declaration / Release note 声明

<!-- release-note
category: None
breaking: false
summary: None
none_reason: Corrects duplicate metadata in the already-published v0.6.0 release notes without introducing a new user-visible change.
-->

## Checklist / 检查清单

- [x] The change is focused and linked to an issue when appropriate. / 改动目标明确，并在适用时关联 Issue。
- [x] I added or updated focused tests for changed behavior. / 我已为变更行为新增或更新聚焦测试。
- [x] I ran the relevant tests and recorded the results above. / 我已运行相关测试并在上方记录结果。
- [x] I updated the required CLI reference, SDK, README, maintainer, and operator-skill documentation. / 我已更新所需的 CLI reference、SDK、README、维护者和 operator-skill 文档。
- [x] I completed the required release-note declaration above; `None` has a concrete reason when selected. / 我已填写上方必需的 release-note 声明；选择 `None` 时已提供具体理由。
- [x] I documented every new timeout, retry, pagination or result limit, truncation, fallback, or downgrade and its evidence. / 我已记录每项新增 timeout、retry、pagination 或结果限制、truncation、fallback 或 downgrade 及其证据。
- [x] I did not add passwords, JWTs, `~/.javdb-cli/auth.json` contents, proxy credentials, private URLs, local state, or private API responses. / 我没有添加密码、JWT、`~/.javdb-cli/auth.json` 内容、代理凭据、私有 URL、本地状态或私有 API 响应。
- [x] I updated migration guidance for every breaking change. / 我已为每个破坏性变更更新迁移指引。

## Summary by Sourcery

修正 v0.6.0 发行说明中的重复元数据，并计划反映排名修复以及来自 #13 的贡献者条目已经在 v0.5.1 中发布。

Documentation:
- 更新双语的 v0.6.0 更新日志，移除重复的排名修复和新贡献者条目，使发行说明与之前的版本准确一致。

Chores:
- 调整 v0.6.0 发布计划 JSON，删除那些已经在 v0.5.1 中交付的变更条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct duplicate metadata in the v0.6.0 release notes and plan to reflect that the rankings fix and contributor entry from #13 were already shipped in v0.5.1.

Documentation:
- Update the bilingual v0.6.0 changelog to remove the duplicated rankings fix and new-contributor entry so the release notes accurately match prior releases.

Chores:
- Adjust the v0.6.0 release plan JSON to drop entries for changes that were already delivered in v0.5.1.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新 v0.6.0 中文与英文发布说明，调整维护事项的归类与展示。
  * 移除已不再适用的排行榜映射与周期规范化修复条目。
  * 删除“新贡献者”章节及相关贡献者记录。
  * 保留 ClawHub 发布验证、兼容性门面移除及 CLI 包结构调整等维护信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->