### PR TITLE
fix(release): backfill ClawHub v0.7.0

### DIFF
--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -15,6 +15,11 @@ on:
         description: Existing published immutable SemVer tag to publish to ClawHub
         required: true
         type: string
+      backfill_from_default_branch:
+        description: Publish a version-only skill metadata repair from the default branch
+        required: false
+        default: false
+        type: boolean
       verify_only:
         description: Verify an existing ClawHub version without publishing again
         required: false
@@ -68,7 +73,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: ${{ steps.release_tag.outputs.value }}
+          ref: ${{ inputs.backfill_from_default_branch == true && github.sha || steps.release_tag.outputs.value }}
 
       - name: Verify immutable release and exact skill source
         id: skill_change
@@ -76,11 +81,14 @@ jobs:
         env:
           RELEASE_TAG: ${{ steps.release_tag.outputs.value }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          BACKFILL_FROM_DEFAULT_BRANCH: ${{ inputs.backfill_from_default_branch }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git show-ref --verify --quiet "refs/tags/$RELEASE_TAG"
           tag_commit=$(git rev-parse "$RELEASE_TAG^{commit}")
+          source_commit=$(git rev-parse HEAD)
+          source_ref=$RELEASE_TAG
           git show-ref --verify --quiet "refs/remotes/origin/$DEFAULT_BRANCH"
           git merge-base --is-ancestor "$tag_commit" "origin/$DEFAULT_BRANCH"
           test "$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq '.draft')" = false
@@ -89,27 +97,46 @@ jobs:
           test "$(grep -c '^version: ' skills/javdb-cli/SKILL.md)" = 1
           test "$skill_version" = "${RELEASE_TAG#v}"
           git cat-file -e "$RELEASE_TAG:skills/javdb-cli/SKILL.md"
-          previous_tag=
-          while IFS= read -r tag; do
-            if [ "$tag" != "$RELEASE_TAG" ] &&
-              test -f "changelog/$tag/en.md" &&
-              test -f "changelog/$tag/zh-CN.md"; then
-              previous_tag=$tag
-              break
-            fi
-          done <<EOF
-          $(git tag --merged "$RELEASE_TAG" --list 'v[0-9]*' --sort=-v:refname)
-          EOF
-          if [ -z "$previous_tag" ]; then
-            printf 'publish=true\n' >> "$GITHUB_OUTPUT"
-          elif git diff --quiet "$previous_tag" "$RELEASE_TAG" -- skills/javdb-cli; then
-            printf 'publish=false\n' >> "$GITHUB_OUTPUT"
-            printf 'Skill unchanged since %s; skipping ClawHub publication.\n' "$previous_tag"
+
+          if [ "$BACKFILL_FROM_DEFAULT_BRANCH" = true ]; then
+            test "$GITHUB_EVENT_NAME" = workflow_dispatch
+            git merge-base --is-ancestor "$tag_commit" "$source_commit"
+            git merge-base --is-ancestor "$source_commit" "origin/$DEFAULT_BRANCH"
+            test "$(git diff --name-only "$RELEASE_TAG" "$source_commit" -- skills/javdb-cli)" = skills/javdb-cli/SKILL.md
+            tag_skill="$RUNNER_TEMP/tag-skill-normalized.md"
+            source_skill="$RUNNER_TEMP/source-skill-normalized.md"
+            test "$(git show "$RELEASE_TAG:skills/javdb-cli/SKILL.md" | grep -c '^version: ')" = 1
+            git show "$RELEASE_TAG:skills/javdb-cli/SKILL.md" | sed 's/^version: .*/version: __VERSION__/' > "$tag_skill"
+            sed 's/^version: .*/version: __VERSION__/' skills/javdb-cli/SKILL.md > "$source_skill"
+            cmp "$tag_skill" "$source_skill"
+            source_ref=$DEFAULT_BRANCH
+            publish=true
           else
-            printf 'publish=true\n' >> "$GITHUB_OUTPUT"
+            test "$source_commit" = "$tag_commit"
+            previous_tag=
+            while IFS= read -r tag; do
+              if [ "$tag" != "$RELEASE_TAG" ] &&
+                test -f "changelog/$tag/en.md" &&
+                test -f "changelog/$tag/zh-CN.md"; then
+                previous_tag=$tag
+                break
+              fi
+            done < <(git tag --merged "$RELEASE_TAG" --list 'v[0-9]*' --sort=-v:refname)
+            if [ -z "$previous_tag" ]; then
+              publish=true
+            elif git diff --quiet "$previous_tag" "$RELEASE_TAG" -- skills/javdb-cli; then
+              publish=false
+              printf 'Skill unchanged since %s; skipping ClawHub publication.\n' "$previous_tag"
+            else
+              publish=true
+            fi
           fi
-          printf 'commit=%s\n' "$tag_commit" >> "$GITHUB_OUTPUT"
-          printf 'skill_version=%s\n' "$skill_version" >> "$GITHUB_OUTPUT"
+          {
+            printf 'publish=%s\n' "$publish"
+            printf 'commit=%s\n' "$source_commit"
+            printf 'source_ref=%s\n' "$source_ref"
+            printf 'skill_version=%s\n' "$skill_version"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Install pinned ClawHub CLI without credentials
         if: steps.skill_change.outputs.publish == 'true' || inputs.verify_only == true
@@ -119,7 +146,7 @@ jobs:
           npm install --global --ignore-scripts clawhub@0.23.1
           test "$(clawhub --cli-version)" = 0.23.1
 
-      - name: Dry-run the exact tagged skill
+      - name: Dry-run the exact approved skill source
         id: dry_run
         if: steps.skill_change.outputs.publish == 'true' || inputs.verify_only == true
         shell: bash
@@ -127,6 +154,7 @@ jobs:
           CLAWHUB_CONFIG_PATH: ${{ runner.temp }}/clawhub/config.json
           RELEASE_TAG: ${{ steps.release_tag.outputs.value }}
           RELEASE_COMMIT: ${{ steps.skill_change.outputs.commit }}
+          SOURCE_REF: ${{ steps.skill_change.outputs.source_ref }}
           SKILL_VERSION: ${{ steps.skill_change.outputs.skill_version }}
         run: |
           set -euo pipefail
@@ -134,7 +162,7 @@ jobs:
           clawhub skill publish skills/javdb-cli \
             --version "$SKILL_VERSION" \
             --source-repo "$GITHUB_REPOSITORY" \
-            --source-ref "$RELEASE_TAG" \
+            --source-ref "$SOURCE_REF" \
             --source-commit "$RELEASE_COMMIT" \
             --source-path skills/javdb-cli \
             --dry-run \
@@ -192,6 +220,7 @@ jobs:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.release_tag.outputs.value }}
           RELEASE_COMMIT: ${{ steps.skill_change.outputs.commit }}
+          SOURCE_REF: ${{ steps.skill_change.outputs.source_ref }}
           SKILL_VERSION: ${{ steps.skill_change.outputs.skill_version }}
           EXPECTED_FINGERPRINT: ${{ steps.dry_run.outputs.fingerprint }}
         run: |
@@ -202,7 +231,7 @@ jobs:
           clawhub skill publish skills/javdb-cli \
             --version "$SKILL_VERSION" \
             --source-repo "$GITHUB_REPOSITORY" \
-            --source-ref "$RELEASE_TAG" \
+            --source-ref "$SOURCE_REF" \
             --source-commit "$RELEASE_COMMIT" \
             --source-path skills/javdb-cli \
             --json > "$RUNNER_TEMP/clawhub-publish.json"

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -226,7 +226,8 @@ environment，同时继续公开 `version --json` 并发布兼容 `checksums.txt
    skill 的 `version` metadata 遗漏同步，可在修复 PR 合并后手动启用
    `backfill_from_default_branch`：workflow 只接受已属于默认分支且位于原 tag 之后的提交，并要求
    `skills/javdb-cli/` 相对该 tag 的唯一差异是 `SKILL.md` 的版本字段；补发仍使用既有 Release 版本，
-   不修改 tag 或二进制资产。
+   不修改 tag 或二进制资产。手动补发时填写既有 `release_tag`、启用
+   `backfill_from_default_branch`，并保持 `verify_only` 关闭。
 
 历史 Release 回写、GitHub description 修改、release-prep PR 合并、创建 tag 与发布均是外部写入。
 在当前会话取得目标版本、范围和影响的明确授权后，先 dry-run，再使用 `sync-history --apply` 或

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -222,7 +222,11 @@ environment，同时继续公开 `version --json` 并发布兼容 `checksums.txt
    `Release` workflow 会由 `publish-clawhub.yml` 通过 `workflow_run` 消费；它 checkout 该 tag、验证
    它属于默认分支，并跳过未改变的 `skills/javdb-cli/`。ClawHub 使用锁定的 `clawhub@0.23.1` 先做
    无凭据 dry-run，再在最后发布步骤读取 `CLAWHUB_TOKEN`。该 token 只应配置为仓库或受保护
-   environment secret，绝不能写入 skill、workflow 日志或 Release notes。
+   environment secret，绝不能写入 skill、workflow 日志或 Release notes。若已发布 tag 中只有产品
+   skill 的 `version` metadata 遗漏同步，可在修复 PR 合并后手动启用
+   `backfill_from_default_branch`：workflow 只接受已属于默认分支且位于原 tag 之后的提交，并要求
+   `skills/javdb-cli/` 相对该 tag 的唯一差异是 `SKILL.md` 的版本字段；补发仍使用既有 Release 版本，
+   不修改 tag 或二进制资产。
 
 历史 Release 回写、GitHub description 修改、release-prep PR 合并、创建 tag 与发布均是外部写入。
 在当前会话取得目标版本、范围和影响的明确授权后，先 dry-run，再使用 `sync-history --apply` 或

--- a/scripts/test-clawhub-publish-workflow.sh
+++ b/scripts/test-clawhub-publish-workflow.sh
@@ -37,7 +37,18 @@ grep -F "path: $github_expr{{ runner.temp }}/clawhub-release-tag" "$clawhub_work
 grep -F 'handoff_dir="$RUNNER_TEMP/clawhub-release-tag"' "$clawhub_workflow" >/dev/null
 grep -F 'git merge-base --is-ancestor' "$clawhub_workflow" >/dev/null
 grep -F "releases/tags/\$RELEASE_TAG" "$clawhub_workflow" >/dev/null
-grep -F "ref: $github_expr{{ steps.release_tag.outputs.value }}" "$clawhub_workflow" >/dev/null
+grep -F 'backfill_from_default_branch:' "$clawhub_workflow" >/dev/null
+grep -F 'BACKFILL_FROM_DEFAULT_BRANCH:' "$clawhub_workflow" >/dev/null
+grep -F 'test "$GITHUB_EVENT_NAME" = workflow_dispatch' "$clawhub_workflow" >/dev/null
+grep -F 'git merge-base --is-ancestor "$source_commit" "origin/$DEFAULT_BRANCH"' "$clawhub_workflow" >/dev/null
+grep -F 'git diff --name-only "$RELEASE_TAG" "$source_commit" -- skills/javdb-cli' "$clawhub_workflow" >/dev/null
+grep -F "git show \"\$RELEASE_TAG:skills/javdb-cli/SKILL.md\" | grep -c '^version: '" "$clawhub_workflow" >/dev/null
+grep -F "git show \"\$RELEASE_TAG:skills/javdb-cli/SKILL.md\"" "$clawhub_workflow" >/dev/null
+grep -F 'cmp "$tag_skill" "$source_skill"' "$clawhub_workflow" >/dev/null
+grep -F "source_ref=\$DEFAULT_BRANCH" "$clawhub_workflow" >/dev/null
+grep -F 'test "$source_commit" = "$tag_commit"' "$clawhub_workflow" >/dev/null
+grep -F "SOURCE_REF: $github_expr{{ steps.skill_change.outputs.source_ref }}" "$clawhub_workflow" >/dev/null
+grep -F -- '--source-ref "$SOURCE_REF"' "$clawhub_workflow" >/dev/null
 
 grep -F 'clawhub@0.23.1' "$clawhub_workflow" >/dev/null
 grep -F 'clawhub skill publish skills/javdb-cli' "$clawhub_workflow" >/dev/null

--- a/skills/javdb-cli/SKILL.md
+++ b/skills/javdb-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 slug: javdb-cli
-version: 0.5.2
+version: 0.7.0
 displayName: JavDB CLI
 summary: Safely operate JavDB through the javdb-cli binary for discovery, authenticated lists, and explicit state changes.
 license: MIT


### PR DESCRIPTION
## Summary / 概述

Repair the missed ClawHub v0.7.0 skill publication without rewriting the immutable release tag or creating v0.7.1. The product skill now declares version 0.7.0, and manual workflow dispatch can publish a tightly constrained version-only metadata backfill from the default branch.

修复遗漏的 ClawHub v0.7.0 skill 发布，不重写不可变发布标签，也不创建 v0.7.1。产品 skill 现声明版本 0.7.0，并允许通过手动 workflow dispatch 从默认分支执行严格受限的仅版本元数据补发。

## Scope and compatibility / 范围与兼容性

- Operator skill: `skills/javdb-cli/SKILL.md` version metadata changes from 0.5.2 to 0.7.0.
- Release behavior: `publish-clawhub.yml` gains `backfill_from_default_branch`; it requires an existing published Release, a source commit already on `main` and after the tag, and no skill difference except the normalized version field.
- CLI commands, flags, public Go SDK, configuration, and binary Release assets: None.
- Compatibility: no breaking changes; `v0.7.0` and its assets remain immutable.

## Verification / 验证

```text
actionlint .github/workflows/publish-clawhub.yml
sh scripts/test-clawhub-publish-workflow.sh
sh scripts/test-workflows.sh
sh scripts/test-documentation.sh
pre-commit run --all-files
git diff --check
YAML language server diagnostics: []
local v0.7.0 backfill provenance guard simulation: passed
```

Real JavDB App API coverage was not run because this change only affects release automation and skill metadata.

Full-repository `actionlint` still reports the two pre-existing SC2046 warnings in `.github/workflows/ci.yml:67` and `.github/workflows/release.yml:189`; the changed workflow passes its focused `actionlint` run.

## Release note declaration / Release note 声明

<!-- release-note
category: Fixed
breaking: false
summary: Allow a released skill with missed version metadata to be safely backfilled to ClawHub from the default branch.
none_reason:
-->

## Checklist / 检查清单

- [x] The change is focused and linked to an issue when appropriate. / 改动目标明确，并在适用时关联 Issue。
- [x] I added or updated focused tests for changed behavior. / 我已为变更行为新增或更新聚焦测试。
- [x] I ran the relevant tests and recorded the results above. / 我已运行相关测试并在上方记录结果。
- [x] I updated the required CLI reference, SDK, README, maintainer, and operator-skill documentation. / 我已更新所需的 CLI reference、SDK、README、维护者和 operator-skill 文档。
- [x] I completed the required release-note declaration above; `None` has a concrete reason when selected. / 我已填写上方必需的 release-note 声明；选择 `None` 时已提供具体理由。
- [x] I documented every new timeout, retry, pagination or result limit, truncation, fallback, or downgrade and its evidence. / 我已记录每项新增 timeout、retry、pagination 或结果限制、truncation、fallback 或 downgrade 及其证据。
- [x] I did not add passwords, JWTs, `~/.javdb-cli/auth.json` contents, proxy credentials, private URLs, local state, or private API responses. / 我没有添加密码、JWT、`~/.javdb-cli/auth.json` 内容、代理凭据、私有 URL、本地状态或私有 API 响应。
- [x] I updated migration guidance for every breaking change. / 我已为每个破坏性变更更新迁移指引。

## Summary by Sourcery

允许 ClawHub 发布工作流在不更改发布标签或资源的情况下，从默认分支为已发布的 `javdb-cli` 技能回填缺失的版本元数据。

New Features:
- 在 ClawHub 发布工作流中新增可选输入 `backfill_from_default_branch`，以便从默认分支进行受控的“仅版本元数据”修复。

Bug Fixes:
- 将 `javdb-cli` 技能的版本元数据从 `0.5.2` 更正为 `0.7.0`，以匹配已发布的 ClawHub 版本。

Enhancements:
- 扩展 ClawHub 发布验证逻辑，用于区分不可变的“基于标签的发布”和受约束的“默认分支回填”，并跟踪已批准的源 ref 与提交。
- 更新维护者文档，说明回填工作流、约束条件以及在修复遗漏的技能版本元数据时的安全保证。

Documentation:
- 在维护者开发指南中记录 `backfill_from_default_branch` 选项及其使用限制。

Tests:
- 扩展 `publish-clawhub` 工作流测试脚本，以覆盖新的 `backfill_from_default_branch` 行为以及源 ref 处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow the ClawHub publish workflow to backfill missing version metadata for an already released javdb-cli skill from the default branch without changing the release tag or assets.

New Features:
- Add an optional backfill_from_default_branch input to the ClawHub publish workflow to enable controlled version-only metadata repair from the default branch.

Bug Fixes:
- Correct the javdb-cli skill version metadata from 0.5.2 to 0.7.0 to match the released ClawHub version.

Enhancements:
- Extend ClawHub publish verification to distinguish between immutable tag-based publishes and constrained default-branch backfills, tracking the approved source ref and commit.
- Update maintainer documentation to describe the backfill workflow, constraints, and safety guarantees for repairing missed skill version metadata.

Documentation:
- Document the backfill_from_default_branch option and its restrictions in the maintainers development guide.

Tests:
- Expand the publish-clawhub workflow test script to cover the new backfill_from_default_branch behavior and source-ref handling.

</details>
