### PR TITLE
fix(cli): make text implicit and expose ndjson output

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ terms and the laws that apply to you.
   filmographies, magnets, rankings, TOP250, collections, authenticated
   watch/want data, and reverse image search with strict number linking
   (`javdb search IMAGE`, `javdb cache reverse-search`).
-- **Composable pipelines** — most commands accept non-TTY stdin batches and
-  speak `javdb.pipeline/v1` JSONL envelopes, so command output can feed the
-  next command (`javdb search --jsonl | javdb detail`).
+- **Composable pipelines** — most commands accept non-TTY stdin batches;
+  explicit `--jsonl` emits `javdb.pipeline/v1` envelopes so command output can
+  feed the next command (`javdb search --jsonl | javdb detail`).
 - **API client, not a scraper** — commands use the App JSON API with explicit
   host and proxy selection; failures remain visible rather than becoming
   fabricated empty results.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ terms and the laws that apply to you.
   watch/want data, and reverse image search with strict number linking
   (`javdb search IMAGE`, `javdb cache reverse-search`).
 - **Composable pipelines** — most commands accept non-TTY stdin batches;
-  explicit `--jsonl` emits `javdb.pipeline/v1` envelopes so command output can
-  feed the next command (`javdb search --jsonl | javdb detail`).
+  explicit `--ndjson` emits `javdb.pipeline/v1` envelopes so command output can
+  feed the next command (`javdb search --ndjson | javdb detail`).
 - **API client, not a scraper** — commands use the App JSON API with explicit
   host and proxy selection; failures remain visible rather than becoming
   fabricated empty results.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,9 +23,9 @@
 - **CLI 与公开 Go SDK**——CLI 与可导入的 `javdb` 包都覆盖搜索、详情、标签、浏览、实体片单、磁力、
   单页评论、选定缩略图/预览媒体下载、排行、TOP250、合集、已认证的想看/看过数据，以及以图搜番
   与严格番号联动（`javdb search IMAGE`、`javdb cache reverse-search`）。
-- **可组合管道**——多数命令接受非 TTY stdin 批处理；显式 `--jsonl` 输出
-  `javdb.pipeline/v1` JSONL 信封，可把上一条命令的结果直接喂给下一条
-  （`javdb search --jsonl | javdb detail`）。
+- **可组合管道**——多数命令接受非 TTY stdin 批处理；显式 `--ndjson` 输出
+  `javdb.pipeline/v1` NDJSON 信封，可把上一条命令的结果直接喂给下一条
+  （`javdb search --ndjson | javdb detail`）。
 - **API 客户端而非爬虫**——命令通过 App JSON API 请求，并显式选择主机与代理；失败会原样
   显示，不会伪装成空结果。
 - **适合 Agent 导航**——`detail` 提供稳定图 ID，命令支持 JSON 输出，并随仓库提供

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,8 +23,9 @@
 - **CLI 与公开 Go SDK**——CLI 与可导入的 `javdb` 包都覆盖搜索、详情、标签、浏览、实体片单、磁力、
   单页评论、选定缩略图/预览媒体下载、排行、TOP250、合集、已认证的想看/看过数据，以及以图搜番
   与严格番号联动（`javdb search IMAGE`、`javdb cache reverse-search`）。
-- **可组合管道**——多数命令接受非 TTY stdin 批处理并输出 `javdb.pipeline/v1` JSONL 信封，
-  上一条命令的结果可以直接喂给下一条（`javdb search --jsonl | javdb detail`）。
+- **可组合管道**——多数命令接受非 TTY stdin 批处理；显式 `--jsonl` 输出
+  `javdb.pipeline/v1` JSONL 信封，可把上一条命令的结果直接喂给下一条
+  （`javdb search --jsonl | javdb detail`）。
 - **API 客户端而非爬虫**——命令通过 App JSON API 请求，并显式选择主机与代理；失败会原样
   显示，不会伪装成空结果。
 - **适合 Agent 导航**——`detail` 提供稳定图 ID，命令支持 JSON 输出，并随仓库提供

--- a/docs/en/cli-reference.md
+++ b/docs/en/cli-reference.md
@@ -192,12 +192,12 @@ Consumers check the kind strictly and prefer a valid `id`; incompatible input
 becomes an in-place `error` envelope. Batch processing preserves input order,
 continues after item failures, and exits non-zero with a summary on stderr.
 
-Output defaults to human text on a TTY and one JSONL envelope per line
-otherwise. `--jsonl`, `--text`, and `--json` are mutually exclusive. Explicit
+Output defaults to human-readable text. `--jsonl`, `--text`, and `--json` are
+mutually exclusive; JSON or JSONL is emitted only when its flag is explicit.
 `--json` keeps the legacy single-item shape and emits a JSON array of envelopes
 for batch input. Producers (e.g. `browse`, `tags`, `lists`, `rankings`,
-`top250`, `watched`, `want`, `recent`) never read stdin; on non-TTY stdout they
-emit one envelope per record.
+`top250`, `watched`, `want`, `recent`) never read stdin and also default to
+text; use `--jsonl` to emit one envelope per record.
 
 ## Entity and list navigation
 

--- a/docs/en/cli-reference.md
+++ b/docs/en/cli-reference.md
@@ -79,12 +79,12 @@ TOP250 and personal-list commands require the default account.
 ```bash
 javdb search KEYWORD|IMAGE [--zone ZONE] [--sort SORT] [--filter-by FILTER] \
   [--type TYPE] [--page N] [--limit N] [--has-magnets] \
-  [--image] [--source NAME] [--no-cache] [--json|--jsonl|--text]
-javdb detail NUMBER [--id] [--magnets] [--json|--jsonl|--text]
-javdb comments NUMBER [--id] [--page N] [--limit N] [--json|--jsonl|--text]
-javdb tags [--zone ZONE] [--refresh] [--json|--jsonl|--text]
+  [--image] [--source NAME] [--no-cache] [--json|--ndjson]
+javdb detail NUMBER [--id] [--magnets] [--json|--ndjson]
+javdb comments NUMBER [--id] [--page N] [--limit N] [--json|--ndjson]
+javdb tags [--zone ZONE] [--refresh] [--json|--ndjson]
 javdb browse [--zone ZONE] [--tag REF]... [--main FLAG]... [--year YYYY] \
-  [--month MONTH] [--sort SORT] [--order asc|desc] [--page N] [--limit N] [--json|--jsonl|--text]
+  [--month MONTH] [--sort SORT] [--order asc|desc] [--page N] [--limit N] [--json|--ndjson]
 ```
 
 `search` accepts `censored`, `uncensored`, `western`, `fc2`, or `all` for
@@ -93,8 +93,8 @@ javdb browse [--zone ZONE] [--tag REF]... [--main FLAG]... [--year YYYY] \
 entity commands. `tags --refresh` downloads and rewrites the local public tag
 cache, so it is not read-only local behavior.
 
-See [Pipeline protocol](#pipeline-protocol) for the `--jsonl`/`--text` output
-contract shared by the commands above and below.
+See [Pipeline protocol](#pipeline-protocol) for the `--ndjson` output contract
+shared by the commands above and below.
 
 `browse --tag` accepts a tag ID, English name, or Chinese name. Repeat
 `--main` for server-side category masks. Use `--json` for programs; human output
@@ -130,7 +130,7 @@ unfinished/live playlists fail explicitly instead of producing a partial file.
 ## Reverse image search
 
 ```bash
-javdb search IMAGE|URL|--image [--source NAME] [--no-cache] [--json|--jsonl|--text]
+javdb search IMAGE|URL|--image [--source NAME] [--no-cache] [--json|--ndjson]
 javdb cache reverse-search [--source NAME] [--clear]
 ```
 
@@ -178,7 +178,7 @@ must enforce their own network boundary.
 ## Pipeline protocol
 
 Commands that take a single positional ref also accept a non-TTY stdin batch.
-Input is classified in fixed order: image magic, `javdb.pipeline/v1` JSONL
+Input is classified in fixed order: image magic, `javdb.pipeline/v1` NDJSON
 envelopes, then plain text lines. Providing both a positional argument and
 non-empty stdin is an ambiguity error.
 
@@ -192,12 +192,12 @@ Consumers check the kind strictly and prefer a valid `id`; incompatible input
 becomes an in-place `error` envelope. Batch processing preserves input order,
 continues after item failures, and exits non-zero with a summary on stderr.
 
-Output defaults to human-readable text. `--jsonl`, `--text`, and `--json` are
-mutually exclusive; JSON or JSONL is emitted only when its flag is explicit.
+Output defaults to human-readable text. `--ndjson` and `--json` are mutually
+exclusive; JSON or NDJSON is emitted only when its flag is explicit.
 `--json` keeps the legacy single-item shape and emits a JSON array of envelopes
 for batch input. Producers (e.g. `browse`, `tags`, `lists`, `rankings`,
 `top250`, `watched`, `want`, `recent`) never read stdin and also default to
-text; use `--jsonl` to emit one envelope per record.
+text; use `--ndjson` to emit one envelope per record.
 
 ## Entity and list navigation
 
@@ -216,9 +216,9 @@ javdb lists related NUMBER [--id] [--page N] [--limit N] [--json]
 ```
 
 Entity options include zone, repeated tag/main filters, sorting, page/limit,
-`--has-magnets`, and JSON/pipeline output (`--json`, `--jsonl`, or `--text`). `lists` without a subcommand reads the
-authenticated user's lists; `list REF` is the entity-filmography command for a
-public or user list.
+`--has-magnets`, and JSON/pipeline output (`--json` or `--ndjson`). `lists`
+without a subcommand reads the authenticated user's lists; `list REF` is the
+entity-filmography command for a public or user list.
 
 ## Magnets, rankings, and personal state
 

--- a/docs/maintainers/architecture.md
+++ b/docs/maintainers/architecture.md
@@ -143,8 +143,8 @@ adapter，统一 multipart `file` 响应协议、三次总请求与 30/60s 退�
 
 `javdb.pipeline/v1` 机器协议核心：typed envelope（schema/kind/ref/id/data/
 meta）、严格 JSONL 与逐行文本解码、输入分类（图片 magic → JSONL → 文本）、
-输出模式（TTY 文本 / 非 TTY JSONL / 显式 --jsonl/--text/--json 互斥，单/批
-JSON cardinality）、批处理执行（顺序保持、原位错误信封、最终非零），以及
+输出模式（默认文本 / 显式 --jsonl/--text/--json 互斥，单/批 JSON
+cardinality）、批处理执行（顺序保持、原位错误信封、最终非零），以及
 Consumer/BatchRunner/ListProducer 三件套把只读/状态命令统一接入。命令不
 复制解析逻辑；`auth login` 与密码提示排除通用 stdin。
 

--- a/docs/maintainers/architecture.md
+++ b/docs/maintainers/architecture.md
@@ -142,8 +142,8 @@ adapter，统一 multipart `file` 响应协议、三次总请求与 30/60s 退�
 ### `internal/cli/pipeline`
 
 `javdb.pipeline/v1` 机器协议核心：typed envelope（schema/kind/ref/id/data/
-meta）、严格 JSONL 与逐行文本解码、输入分类（图片 magic → JSONL → 文本）、
-输出模式（默认文本 / 显式 --jsonl/--text/--json 互斥，单/批 JSON
+meta）、严格 NDJSON 与逐行文本解码、输入分类（图片 magic → NDJSON → 文本）、
+输出模式（默认文本 / 显式 --ndjson/--json 互斥，单/批 JSON
 cardinality）、批处理执行（顺序保持、原位错误信封、最终非零），以及
 Consumer/BatchRunner/ListProducer 三件套把只读/状态命令统一接入。命令不
 复制解析逻辑；`auth login` 与密码提示排除通用 stdin。

--- a/docs/zh-CN/cli-reference.md
+++ b/docs/zh-CN/cli-reference.md
@@ -66,12 +66,12 @@ token 时自动携带，失效则回退匿名）；TOP250 和个人列表命令�
 ```bash
 javdb search KEYWORD|IMAGE [--zone ZONE] [--sort SORT] [--filter-by FILTER] \
   [--type TYPE] [--page N] [--limit N] [--has-magnets] \
-  [--image] [--source NAME] [--no-cache] [--json|--jsonl|--text]
-javdb detail NUMBER [--id] [--magnets] [--json|--jsonl|--text]
-javdb comments NUMBER [--id] [--page N] [--limit N] [--json|--jsonl|--text]
-javdb tags [--zone ZONE] [--refresh] [--json|--jsonl|--text]
+  [--image] [--source NAME] [--no-cache] [--json|--ndjson]
+javdb detail NUMBER [--id] [--magnets] [--json|--ndjson]
+javdb comments NUMBER [--id] [--page N] [--limit N] [--json|--ndjson]
+javdb tags [--zone ZONE] [--refresh] [--json|--ndjson]
 javdb browse [--zone ZONE] [--tag REF]... [--main FLAG]... [--year YYYY] \
-  [--month MONTH] [--sort SORT] [--order asc|desc] [--page N] [--limit N] [--json|--jsonl|--text]
+  [--month MONTH] [--sort SORT] [--order asc|desc] [--page N] [--limit N] [--json|--ndjson]
 ```
 
 `search --zone` 可用 `censored`、`uncensored`、`western`、`fc2`、`all`；`--type`
@@ -103,7 +103,7 @@ playlist；master playlist、byte-range 媒体、fragmented MP4 媒体，以及�
 ## 以图搜番
 
 ```bash
-javdb search IMAGE|URL|--image [--source NAME] [--no-cache] [--json|--jsonl|--text]
+javdb search IMAGE|URL|--image [--source NAME] [--no-cache] [--json|--ndjson]
 javdb cache reverse-search [--source NAME] [--clear]
 ```
 
@@ -144,7 +144,7 @@ SDK 嵌入方必须自行施加网络边界。
 ## 管道协议
 
 接受单个位置 ref 的命令也接受非 TTY stdin 批处理。输入按固定顺序分类：图片 magic、
-`javdb.pipeline/v1` JSONL 信封、逐行纯文本。位置参数与非空 stdin 同时存在是歧义错误。
+`javdb.pipeline/v1` NDJSON 信封、逐行纯文本。位置参数与非空 stdin 同时存在是歧义错误。
 
 ```json
 {"schema":"javdb.pipeline/v1","kind":"movie","ref":"SSIS-589","id":"9DGB5X","data":{},"meta":{}}
@@ -155,10 +155,10 @@ SDK 嵌入方必须自行施加网络边界。
 消费者严格检查 kind 并优先使用合法 `id`；不兼容输入生成原位 `error` 信封。批处理保持输入
 顺序、单项失败继续执行，最终非零并在 stderr 输出汇总。
 
-输出默认使用人类可读文本。`--jsonl`、`--text` 与 `--json` 互斥；只有显式指定对应 flag
-才输出 JSON 或 JSONL。显式 `--json` 单项保持既有 shape，多项输出信封数组。生产者命令
+输出默认使用人类可读文本。`--ndjson` 与 `--json` 互斥；只有显式指定对应 flag
+才输出 JSON 或 NDJSON。显式 `--json` 单项保持既有 shape，多项输出信封数组。生产者命令
 （如 `browse`、`tags`、`lists`、`rankings`、`top250`、`watched`、`want`、`recent`）
-不读 stdin 且同样默认文本；使用 `--jsonl` 才逐条输出信封。
+不读 stdin 且同样默认文本；使用 `--ndjson` 才逐条输出信封。
 
 ## 实体与合集导航
 

--- a/docs/zh-CN/cli-reference.md
+++ b/docs/zh-CN/cli-reference.md
@@ -155,10 +155,10 @@ SDK 嵌入方必须自行施加网络边界。
 消费者严格检查 kind 并优先使用合法 `id`；不兼容输入生成原位 `error` 信封。批处理保持输入
 顺序、单项失败继续执行，最终非零并在 stderr 输出汇总。
 
-输出默认：TTY 人类文本，非 TTY 每行一个 JSONL 信封。`--jsonl`、`--text` 与 `--json`
-互斥。显式 `--json` 单项保持既有 shape，多项输出信封数组。生产者命令（如 `browse`、
-`tags`、`lists`、`rankings`、`top250`、`watched`、`want`、`recent`）不读 stdin；
-非 TTY stdout 逐条输出信封。
+输出默认使用人类可读文本。`--jsonl`、`--text` 与 `--json` 互斥；只有显式指定对应 flag
+才输出 JSON 或 JSONL。显式 `--json` 单项保持既有 shape，多项输出信封数组。生产者命令
+（如 `browse`、`tags`、`lists`、`rankings`、`top250`、`watched`、`want`、`recent`）
+不读 stdin 且同样默认文本；使用 `--jsonl` 才逐条输出信封。
 
 ## 实体与合集导航
 

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -60,27 +60,29 @@ jout=$(run version --json)
 assert_json "version --json has version/commit/build_date" "$jout" "all(k in d for k in ('version','commit','build_date'))"
 
 echo "== search =="
-out=$(run search SSIS-001 --limit 1 --text)
+out=$(run search SSIS-001 --limit 1)
 assert_substring "search text has number SSIS-001" "$out" "SSIS-001"
 jout=$(run search SSIS-001 --limit 1 --json)
 assert_json "search --json has movies[0].id" "$jout" "bool(d.get('movies') and d['movies'][0].get('id'))"
 # thumb_url 受 CDN/地区影响可为空,只校验键存在,反映 list 条目契约。
 assert_json "search --json exposes thumb_url key" "$jout" "'thumb_url' in d['movies'][0]"
+nout=$(run search SSIS-001 --limit 1 --ndjson)
+assert_json "search --ndjson emits a pipeline envelope" "$nout" "d.get('schema') == 'javdb.pipeline/v1' and d.get('kind') == 'movie'"
 
 echo "== rankings =="
-out=$(run rankings movies --period week --text)
+out=$(run rankings movies --period week)
 assert_substring "rankings movies week has a row" "$out" $'\t'
-out=$(run rankings actors --period week --text)
+out=$(run rankings actors --period week)
 assert_substring "rankings actors week has tab row" "$out" $'\t'
-out=$(run rankings playback --period week --text)
+out=$(run rankings playback --period week)
 assert_substring "rankings playback week has a row" "$out" $'\t'
 
 echo "== browse =="
-out=$(run browse --zone censored --limit 1 --text)
+out=$(run browse --zone censored --limit 1)
 assert_substring "browse returns a movie row" "$out" $'\t'
 
 echo "== detail (image fields) =="
-out=$(run detail SSIS-001 --text)
+out=$(run detail SSIS-001)
 assert_substring "detail has 番号" "$out" "番号"
 jout=$(run detail SSIS-001 --json)
 # preview_images 在 CI/地区差异下可能为空数组,校验键存在与类型即可。
@@ -89,13 +91,13 @@ assert_json "detail --json exposes thumb_url key" "$jout" "'thumb_url' in d"
 assert_json "detail --json exposes cover_url key" "$jout" "'cover_url' in d"
 
 echo "== tags =="
-out=$(run tags --zone censored --text)
+out=$(run tags --zone censored)
 assert_substring "tags lists main header" "$out" "main"
 
 echo "== magnets (read-only; uses token if available) =="
 jout=$(run magnets SSIS-001 --best --json)
 assert_json "magnets --best --json has magnet_uri" "$jout" "bool(d.get('magnet_uri'))"
-out=$(run magnets SSIS-001 --cnsub --text)
+out=$(run magnets SSIS-001 --cnsub)
 assert_substring "magnets text has magnet uri line" "$out" "magnet:?xt=urn:btih:"
 
 # --- 以下命令需要登录 ---
@@ -113,33 +115,33 @@ else
   assert_json "auth check --json ok" "$out" "d.get('ok') is True or d.get('valid') is True or 'user' in d or 'username' in d or bool(d)"
 
   echo "== top250 =="
-  out=$(run top250 --zone censored --limit 1 --text)
+  out=$(run top250 --zone censored --limit 1)
   assert_substring "top250 has ranked row" "$out" "#1"
   out=$(run top250 --zone censored --limit 1 --json)
   assert_json "top250 --json ok" "$out" "'movies' in d and len(d['movies']) == 1"
 
   echo "== watched / want / recent =="
-  out=$(run watched --text)
+  out=$(run watched)
   assert_substring "watched returns rows" "$out" $'\t'
-  out=$(run want --text)
+  out=$(run want)
   assert_substring "want returns rows" "$out" $'\t'
-  out=$(run recent --text)
+  out=$(run recent)
   assert_substring "recent returns rows" "$out" $'\t'
 
   echo "== collections =="
-  out=$(run collections actors --text)
+  out=$(run collections actors)
   assert_substring "collections actors has row" "$out" $'\t'
 
   echo "== lists =="
-  out=$(run lists --limit 1 --text)
+  out=$(run lists --limit 1)
   assert_substring "lists has row" "$out" $'\t'
 
   echo "== entity filmography =="
-  out=$(run actor 葵つかさ --limit 1 --text)
+  out=$(run actor 葵つかさ --limit 1)
   assert_substring "actor filmography has row" "$out" $'\t'
 
   echo "== lists related =="
-  out=$(run lists related SSIS-001 --limit 1 --text)
+  out=$(run lists related SSIS-001 --limit 1)
   assert_substring "lists related has row" "$out" $'\t'
 fi
 

--- a/internal/cli/commands/auth/remove.go
+++ b/internal/cli/commands/auth/remove.go
@@ -67,6 +67,6 @@ func NewRemove(streams *invocation.Streams) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }

--- a/internal/cli/commands/auth/remove.go
+++ b/internal/cli/commands/auth/remove.go
@@ -16,7 +16,7 @@ import (
 
 // NewRemove builds the auth remove command.
 func NewRemove(streams *invocation.Streams) *cobra.Command {
-	var asJSON, asJSONL, asText bool
+	var asJSON, asNDJSON bool
 	runOne := func(userID int64) error {
 		// 参数校验通过后再按"第一个真实命令创建配置"契约触发首次创建。
 		if err := paths.EnsureDefaultConfigFile(); err != nil {
@@ -62,11 +62,10 @@ func NewRemove(streams *invocation.Streams) *cobra.Command {
 		Short: "Remove a saved account",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(command *cobra.Command, args []string) error {
-			return runner.Execute(streams, args, asJSONL, asText, asJSON)
+			return runner.Execute(streams, args, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }

--- a/internal/cli/commands/auth/use.go
+++ b/internal/cli/commands/auth/use.go
@@ -73,6 +73,6 @@ func NewUse(streams *invocation.Streams) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }

--- a/internal/cli/commands/auth/use.go
+++ b/internal/cli/commands/auth/use.go
@@ -16,7 +16,7 @@ import (
 
 // NewUse builds the auth use command.
 func NewUse(streams *invocation.Streams) *cobra.Command {
-	var asJSON, asJSONL, asText bool
+	var asJSON, asNDJSON bool
 	runOne := func(userID int64) (string, error) {
 		// 参数校验通过后再按"第一个真实命令创建配置"契约触发首次创建。
 		if err := paths.EnsureDefaultConfigFile(); err != nil {
@@ -68,11 +68,10 @@ func NewUse(streams *invocation.Streams) *cobra.Command {
 		Short: "Set the default account",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(command *cobra.Command, args []string) error {
-			return runner.Execute(streams, args, asJSONL, asText, asJSON)
+			return runner.Execute(streams, args, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }

--- a/internal/cli/commands/browse/browse.go
+++ b/internal/cli/commands/browse/browse.go
@@ -21,7 +21,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 		page, limit                    int
 		tagRefs, mainFlags             []string
 		hasMagnets                     bool
-		asJSON, asJSONL, asText        bool
+		asJSON, asNDJSON               bool
 	)
 	fetch := func(c *javdb.Client, ctx context.Context) ([]map[string]any, error) {
 		var tagIDs []string
@@ -62,7 +62,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 		Use:   "browse",
 		Short: "Browse movies by content tags / year / month",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return producer.Execute(streams, asJSONL, asText, asJSON)
+			return producer.Execute(streams, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().StringVar(&zone, "zone", "censored", "censored|uncensored|western|fc2")
@@ -76,7 +76,6 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().IntVar(&limit, "limit", 20, "Page size")
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "JSON output")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }

--- a/internal/cli/commands/browse/browse.go
+++ b/internal/cli/commands/browse/browse.go
@@ -77,6 +77,6 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "JSON output")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }

--- a/internal/cli/commands/collections/collections.go
+++ b/internal/cli/commands/collections/collections.go
@@ -58,7 +58,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }
 

--- a/internal/cli/commands/collections/collections.go
+++ b/internal/cli/commands/collections/collections.go
@@ -18,7 +18,7 @@ import (
 
 // New builds the collection listing command.
 func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Command {
-	var asJSON, asJSONL, asText bool
+	var asJSON, asNDJSON bool
 	runner := &pipeline.BatchRunner{
 		Name:       "collections",
 		LegacyJSON: true,
@@ -53,12 +53,11 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 		Short: "List a collection: actors|series|codes|makers|directors",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runner.Execute(streams, args, asJSONL, asText, asJSON)
+			return runner.Execute(streams, args, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }
 

--- a/internal/cli/commands/comments/comments.go
+++ b/internal/cli/commands/comments/comments.go
@@ -17,7 +17,7 @@ import (
 // New builds the one-page movie review command.
 func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Command {
 	var page, limit int
-	var isID, asJSON, asJSONL, asText bool
+	var isID, asJSON, asNDJSON bool
 	runner := &pipeline.BatchRunner{
 		Name:       "comments",
 		LegacyJSON: true,
@@ -94,14 +94,13 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 			if limit < 1 {
 				return fmt.Errorf("--limit must be positive")
 			}
-			return runner.Execute(streams, args, asJSONL, asText, asJSON)
+			return runner.Execute(streams, args, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().BoolVarP(&isID, "id", "i", false, "Treat NUMBER as internal movie id")
 	cmd.Flags().IntVar(&page, "page", 1, "Page number")
 	cmd.Flags().IntVar(&limit, "limit", 20, "Page size")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }

--- a/internal/cli/commands/comments/comments.go
+++ b/internal/cli/commands/comments/comments.go
@@ -102,6 +102,6 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().IntVar(&limit, "limit", 20, "Page size")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }

--- a/internal/cli/commands/config/config.go
+++ b/internal/cli/commands/config/config.go
@@ -139,7 +139,7 @@ func New(streams *invocation.Streams) *cobra.Command {
 
 // newGet 构建 config get：一个 key 或无 key 时的非 TTY stdin 批处理。
 func newGet(streams *invocation.Streams) *cobra.Command {
-	var asJSON, asJSONL, asText bool
+	var asJSON, asNDJSON bool
 	load := func() (settings.Settings, string, error) {
 		if err := paths.EnsureDefaultConfigFile(); err != nil {
 			return settings.Settings{}, "", err
@@ -209,18 +209,17 @@ func newGet(streams *invocation.Streams) *cobra.Command {
 					return nil
 				}
 			}
-			return runner.Execute(streams, args, asJSONL, asText, asJSON)
+			return runner.Execute(streams, args, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }
 
 // newUnset 构建 config unset：一个 key 或非 TTY stdin key 批处理。
 func newUnset(streams *invocation.Streams) *cobra.Command {
-	var asJSON, asJSONL, asText bool
+	var asJSON, asNDJSON bool
 	runOne := func(key string) error {
 		if !knownConfigKey(key) {
 			return fmt.Errorf("unknown key %q", key)
@@ -265,12 +264,11 @@ func newUnset(streams *invocation.Streams) *cobra.Command {
 		Short: "Clear a config key to default",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(command *cobra.Command, args []string) error {
-			return runner.Execute(streams, args, asJSONL, asText, asJSON)
+			return runner.Execute(streams, args, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }
 

--- a/internal/cli/commands/config/config.go
+++ b/internal/cli/commands/config/config.go
@@ -214,7 +214,7 @@ func newGet(streams *invocation.Streams) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }
 
@@ -270,7 +270,7 @@ func newUnset(streams *invocation.Streams) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }
 

--- a/internal/cli/commands/config/config_test.go
+++ b/internal/cli/commands/config/config_test.go
@@ -220,12 +220,12 @@ func TestConfigGetListsReverseSearchScalars(t *testing.T) {
 	}
 }
 
-// TestConfigGetStdinBatch 无 key + 非 TTY stdin：key 批处理输出 config_key 信封。
+// TestConfigGetStdinBatch 无 key + 非 TTY stdin：显式 JSONL 批处理输出 config_key 信封。
 func TestConfigGetStdinBatch(t *testing.T) {
 	isolateHome(t)
 	streams := invocation.NewStreams(strings.NewReader("host\nlang\n"), &bytes.Buffer{}, &bytes.Buffer{})
 	command := New(streams)
-	command.SetArgs([]string{"get"})
+	command.SetArgs([]string{"get", "--jsonl"})
 	if err := command.Execute(); err != nil {
 		t.Fatalf("get batch: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestConfigGetBatchRedactsProxyCredentials(t *testing.T) {
 	}
 	streams := invocation.NewStreams(strings.NewReader("https_proxy\n"), &bytes.Buffer{}, &bytes.Buffer{})
 	command := New(streams)
-	command.SetArgs([]string{"get"})
+	command.SetArgs([]string{"get", "--jsonl"})
 	if err := command.Execute(); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/commands/config/config_test.go
+++ b/internal/cli/commands/config/config_test.go
@@ -220,12 +220,12 @@ func TestConfigGetListsReverseSearchScalars(t *testing.T) {
 	}
 }
 
-// TestConfigGetStdinBatch 无 key + 非 TTY stdin：显式 JSONL 批处理输出 config_key 信封。
+// TestConfigGetStdinBatch 无 key + 非 TTY stdin：显式 NDJSON 批处理输出 config_key 信封。
 func TestConfigGetStdinBatch(t *testing.T) {
 	isolateHome(t)
 	streams := invocation.NewStreams(strings.NewReader("host\nlang\n"), &bytes.Buffer{}, &bytes.Buffer{})
 	command := New(streams)
-	command.SetArgs([]string{"get", "--jsonl"})
+	command.SetArgs([]string{"get", "--ndjson"})
 	if err := command.Execute(); err != nil {
 		t.Fatalf("get batch: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestConfigGetBatchRedactsProxyCredentials(t *testing.T) {
 	}
 	streams := invocation.NewStreams(strings.NewReader("https_proxy\n"), &bytes.Buffer{}, &bytes.Buffer{})
 	command := New(streams)
-	command.SetArgs([]string{"get", "--jsonl"})
+	command.SetArgs([]string{"get", "--ndjson"})
 	if err := command.Execute(); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/commands/detail/detail.go
+++ b/internal/cli/commands/detail/detail.go
@@ -107,6 +107,6 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().BoolVar(&withMagnets, "magnets", false, "Also list magnet links")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }

--- a/internal/cli/commands/detail/detail.go
+++ b/internal/cli/commands/detail/detail.go
@@ -16,7 +16,7 @@ import (
 
 // New builds the movie detail command (graph ids for agent navigation).
 func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Command {
-	var isID, withMagnets, asJSON, asJSONL, asText bool
+	var isID, withMagnets, asJSON, asNDJSON bool
 	runner := &pipeline.BatchRunner{
 		Name:       "detail",
 		LegacyJSON: true,
@@ -100,13 +100,12 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 		Short: "Show movie detail (graph ids for agent navigation)",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runner.Execute(streams, args, asJSONL, asText, asJSON)
+			return runner.Execute(streams, args, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().BoolVarP(&isID, "id", "i", false, "Treat argument as internal movie id")
 	cmd.Flags().BoolVar(&withMagnets, "magnets", false, "Also list magnet links")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }

--- a/internal/cli/commands/detail/detail_pipeline_test.go
+++ b/internal/cli/commands/detail/detail_pipeline_test.go
@@ -42,7 +42,7 @@ func TestDetailJSONLStdinBatch(t *testing.T) {
 `
 	streams := invocation.NewStreams(strings.NewReader(stdin), &bytes.Buffer{}, &bytes.Buffer{})
 	cmd := New(&invocation.RootOptions{Host: server.URL}, streams)
-	cmd.SetArgs([]string{})
+	cmd.SetArgs([]string{"--jsonl"})
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "1 of 2 items failed") {
 		t.Fatalf("expected batch failure, got %v", err)

--- a/internal/cli/commands/detail/detail_pipeline_test.go
+++ b/internal/cli/commands/detail/detail_pipeline_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/FlanChanXwO/javdb-cli/internal/cli/invocation"
 )
 
-// TestDetailJSONLStdinBatch 从 stdin 消费 movie 信封批，逐项解析并输出详情
+// TestDetailNDJSONStdinBatch 从 stdin 消费 movie 信封批，逐项解析并输出详情
 // 信封；不兼容 kind 原位错误。
-func TestDetailJSONLStdinBatch(t *testing.T) {
+func TestDetailNDJSONStdinBatch(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("USERPROFILE", t.TempDir())
 	t.Setenv("HOMEDRIVE", filepath.VolumeName(t.TempDir()))
@@ -42,7 +42,7 @@ func TestDetailJSONLStdinBatch(t *testing.T) {
 `
 	streams := invocation.NewStreams(strings.NewReader(stdin), &bytes.Buffer{}, &bytes.Buffer{})
 	cmd := New(&invocation.RootOptions{Host: server.URL}, streams)
-	cmd.SetArgs([]string{"--jsonl"})
+	cmd.SetArgs([]string{"--ndjson"})
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "1 of 2 items failed") {
 		t.Fatalf("expected batch failure, got %v", err)

--- a/internal/cli/commands/download/download.go
+++ b/internal/cli/commands/download/download.go
@@ -191,7 +191,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().StringVar(&previewVideoPath, "preview-video", "", "Save preview HLS video to PATH (supports {number}/{id})")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }
 

--- a/internal/cli/commands/download/download.go
+++ b/internal/cli/commands/download/download.go
@@ -20,7 +20,7 @@ import (
 func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Command {
 	var thumbnailPath, previewImagePath, previewVideoPath string
 	var isID bool
-	var asJSON, asJSONL, asText bool
+	var asJSON, asNDJSON bool
 
 	pathFlags := func() []string {
 		return []string{thumbnailPath, previewImagePath, previewVideoPath}
@@ -182,7 +182,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 			if strings.TrimSpace(thumbnailPath) == "" && strings.TrimSpace(previewImagePath) == "" && strings.TrimSpace(previewVideoPath) == "" {
 				return fmt.Errorf("set at least one of --thumbnail, --preview-image, or --preview-video")
 			}
-			return runner.Execute(streams, args, asJSONL, asText, asJSON)
+			return runner.Execute(streams, args, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().BoolVarP(&isID, "id", "i", false, "Treat NUMBER as internal movie id")
@@ -190,8 +190,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().StringVar(&previewImagePath, "preview-image", "", "Save only the first preview image to PATH (supports {number}/{id})")
 	cmd.Flags().StringVar(&previewVideoPath, "preview-video", "", "Save preview HLS video to PATH (supports {number}/{id})")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }
 

--- a/internal/cli/commands/download/download_test.go
+++ b/internal/cli/commands/download/download_test.go
@@ -105,7 +105,7 @@ func TestDownloadBatchPreflightRejectsDuplicateTargets(t *testing.T) {
 	streams = invocation.NewStreams(strings.NewReader("SSIS-589\nHZGD-246\n"), &bytes.Buffer{}, &bytes.Buffer{})
 	cmd = New(&invocation.RootOptions{Host: server.URL}, streams)
 	cmd.SetArgs([]string{"--thumbnail", dir + "/{number}.jpg"})
-	// 改用同 number 不同 id 输入避免重复：用 JSONL 提供唯一 id。
+	// 改用同 number 不同 id 输入避免重复：用 NDJSON 提供唯一 id。
 	streams = invocation.NewStreams(strings.NewReader("{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"movie\",\"ref\":\"SSIS-589\",\"id\":\"EXISTING\"}\n{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"movie\",\"ref\":\"SSIS-589\",\"id\":\"OTHER\"}\n"), &bytes.Buffer{}, &bytes.Buffer{})
 	cmd = New(&invocation.RootOptions{Host: server.URL}, streams)
 	cmd.SetArgs([]string{"--thumbnail", dir + "/{id}.jpg"})

--- a/internal/cli/commands/lists/lists.go
+++ b/internal/cli/commands/lists/lists.go
@@ -75,7 +75,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().StringVar(&sortBy, "sort-by", "created", "created|name|movies_count|views_count|updated|default")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "JSON output")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 
 	cmd.AddCommand(NewShow(options, streams))
 	cmd.AddCommand(NewSearch(options, streams))

--- a/internal/cli/commands/lists/lists.go
+++ b/internal/cli/commands/lists/lists.go
@@ -62,20 +62,19 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 			})
 		},
 	}
-	var asJSONL, asText bool
+	var asNDJSON bool
 	cmd := &cobra.Command{
 		Use:   "lists",
 		Short: "My 合集; subcommands: show/search/related",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return producer.Execute(streams, asJSONL, asText, asJSON)
+			return producer.Execute(streams, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().IntVar(&page, "page", 1, "Page")
 	cmd.Flags().IntVar(&limit, "limit", 20, "Page size")
 	cmd.Flags().StringVar(&sortBy, "sort-by", "created", "created|name|movies_count|views_count|updated|default")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "JSON output")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 
 	cmd.AddCommand(NewShow(options, streams))
 	cmd.AddCommand(NewSearch(options, streams))

--- a/internal/cli/commands/lists/related.go
+++ b/internal/cli/commands/lists/related.go
@@ -16,7 +16,7 @@ import (
 func NewRelated(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Command {
 	var isID bool
 	var page, limit int
-	var asJSON, asJSONL, asText bool
+	var asJSON, asNDJSON bool
 	runOne := func(c *javdb.Client, ctx context.Context, ref string, useID bool) (string, []map[string]any, error) {
 		mid := ref
 		var err error
@@ -67,14 +67,13 @@ func NewRelated(options *invocation.RootOptions, streams *invocation.Streams) *c
 		Short: "Public 合集 related to a movie",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runner.Execute(streams, args, asJSONL, asText, asJSON)
+			return runner.Execute(streams, args, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().BoolVarP(&isID, "id", "i", false, "Treat NUMBER as internal movie id")
 	cmd.Flags().IntVar(&page, "page", 1, "Page")
 	cmd.Flags().IntVar(&limit, "limit", 20, "Page size")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "JSON output")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }

--- a/internal/cli/commands/lists/related.go
+++ b/internal/cli/commands/lists/related.go
@@ -75,6 +75,6 @@ func NewRelated(options *invocation.RootOptions, streams *invocation.Streams) *c
 	cmd.Flags().IntVar(&limit, "limit", 20, "Page size")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "JSON output")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }

--- a/internal/cli/commands/lists/search.go
+++ b/internal/cli/commands/lists/search.go
@@ -68,6 +68,6 @@ func NewSearch(options *invocation.RootOptions, streams *invocation.Streams) *co
 	cmd.Flags().StringVar(&zone, "zone", "all", "censored|uncensored|western|fc2|all")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "JSON output")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }

--- a/internal/cli/commands/lists/search.go
+++ b/internal/cli/commands/lists/search.go
@@ -16,7 +16,7 @@ import (
 func NewSearch(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Command {
 	var page, limit int
 	var zone string
-	var asJSON, asJSONL, asText bool
+	var asJSON, asNDJSON bool
 	runOne := func(c *javdb.Client, ctx context.Context, keyword string) ([]map[string]any, error) {
 		res, err := c.Search(ctx, keyword, javdb.SearchOptions{
 			Page: page, Limit: limit, Zone: zone, Type: "list",
@@ -60,14 +60,13 @@ func NewSearch(options *invocation.RootOptions, streams *invocation.Streams) *co
 		Short: "Search public 合集",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runner.Execute(streams, args, asJSONL, asText, asJSON)
+			return runner.Execute(streams, args, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().IntVar(&page, "page", 1, "Page")
 	cmd.Flags().IntVar(&limit, "limit", 0, "Page size")
 	cmd.Flags().StringVar(&zone, "zone", "all", "censored|uncensored|western|fc2|all")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "JSON output")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }

--- a/internal/cli/commands/lists/show.go
+++ b/internal/cli/commands/lists/show.go
@@ -93,7 +93,7 @@ func NewShow(options *invocation.RootOptions, streams *invocation.Streams) *cobr
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "JSON output")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }
 

--- a/internal/cli/commands/lists/show.go
+++ b/internal/cli/commands/lists/show.go
@@ -17,7 +17,7 @@ import (
 
 // NewShow builds the lists show command.
 func NewShow(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Command {
-	var asJSON, asJSONL, asText bool
+	var asJSON, asNDJSON bool
 	runOne := func(c *javdb.Client, ctx context.Context, ref string) (string, map[string]any, error) {
 		eid, err := c.ResolveEntity(ctx, "list", ref, "censored")
 		if err != nil {
@@ -88,12 +88,11 @@ func NewShow(options *invocation.RootOptions, streams *invocation.Streams) *cobr
 		Short: "Show 合集 meta (movies: use list <id>)",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runner.Execute(streams, args, asJSONL, asText, asJSON)
+			return runner.Execute(streams, args, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "JSON output")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }
 

--- a/internal/cli/commands/magnets/magnets.go
+++ b/internal/cli/commands/magnets/magnets.go
@@ -122,7 +122,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().BoolVarP(&isID, "id", "i", false, "Treat NUMBER as internal movie id")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }
 

--- a/internal/cli/commands/magnets/magnets.go
+++ b/internal/cli/commands/magnets/magnets.go
@@ -19,9 +19,9 @@ import (
 // New builds the magnet listing and best-magnet selection command.
 func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Command {
 	var (
-		cnsub, hd, best, isID   bool
-		asJSON, asJSONL, asText bool
-		minSize                 string
+		cnsub, hd, best, isID bool
+		asJSON, asNDJSON      bool
+		minSize               string
 	)
 	fetch := func(c *javdb.Client, ctx context.Context, ref string, useID bool) (string, []map[string]any, error) {
 		mid := ref
@@ -112,7 +112,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 		Short: "List magnet links for a movie",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runner.Execute(streams, args, asJSONL, asText, asJSON)
+			return runner.Execute(streams, args, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().BoolVar(&cnsub, "cnsub", false, "Only magnets with Chinese subtitles")
@@ -121,8 +121,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().BoolVar(&best, "best", false, "Pick single best magnet (cnsub > hd > size)")
 	cmd.Flags().BoolVarP(&isID, "id", "i", false, "Treat NUMBER as internal movie id")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }
 

--- a/internal/cli/commands/mark/mark.go
+++ b/internal/cli/commands/mark/mark.go
@@ -19,7 +19,7 @@ import (
 // New builds the mark command (watched or want).
 func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Command {
 	var watched, want, isID bool
-	var asJSON, asJSONL, asText bool
+	var asJSON, asNDJSON bool
 	var score int
 	var content string
 	fetch := func(c *javdb.Client, ctx context.Context, ref string, useID bool, status string) (string, map[string]any, error) {
@@ -82,7 +82,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 			if watched == want && (len(args) == 1 || stdinHasContent(streams)) {
 				return fmt.Errorf("specify exactly one of --watched or --want")
 			}
-			return runner.Execute(streams, args, asJSONL, asText, asJSON)
+			return runner.Execute(streams, args, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().BoolVar(&watched, "watched", false, "Mark as 看過")
@@ -91,8 +91,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().StringVar(&content, "content", "", "Optional review text")
 	cmd.Flags().BoolVarP(&isID, "id", "i", false, "Treat NUMBER as internal movie id")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }
 

--- a/internal/cli/commands/mark/mark.go
+++ b/internal/cli/commands/mark/mark.go
@@ -92,7 +92,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().BoolVarP(&isID, "id", "i", false, "Treat NUMBER as internal movie id")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }
 

--- a/internal/cli/commands/mark/mark_pipeline_test.go
+++ b/internal/cli/commands/mark/mark_pipeline_test.go
@@ -37,7 +37,7 @@ func TestMarkBatchPartialFailure(t *testing.T) {
 
 	streams := invocation.NewStreams(strings.NewReader("SSIS-589\nGHOST-999\n"), &bytes.Buffer{}, &bytes.Buffer{})
 	cmd := New(&invocation.RootOptions{Host: server.URL}, streams)
-	cmd.SetArgs([]string{"--watched", "--jsonl"})
+	cmd.SetArgs([]string{"--watched", "--ndjson"})
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "1 of 2 items failed") {
 		t.Fatalf("expected 1-of-2 failure, got %v", err)

--- a/internal/cli/commands/mark/mark_pipeline_test.go
+++ b/internal/cli/commands/mark/mark_pipeline_test.go
@@ -37,7 +37,7 @@ func TestMarkBatchPartialFailure(t *testing.T) {
 
 	streams := invocation.NewStreams(strings.NewReader("SSIS-589\nGHOST-999\n"), &bytes.Buffer{}, &bytes.Buffer{})
 	cmd := New(&invocation.RootOptions{Host: server.URL}, streams)
-	cmd.SetArgs([]string{"--watched"})
+	cmd.SetArgs([]string{"--watched", "--jsonl"})
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "1 of 2 items failed") {
 		t.Fatalf("expected 1-of-2 failure, got %v", err)

--- a/internal/cli/commands/rankings/actors.go
+++ b/internal/cli/commands/rankings/actors.go
@@ -56,7 +56,7 @@ func NewActors(options *invocation.RootOptions, streams *invocation.Streams) *co
 	cmd.Flags().StringVar(&period, "period", "day", "day|week|month")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }
 

--- a/internal/cli/commands/rankings/actors.go
+++ b/internal/cli/commands/rankings/actors.go
@@ -17,7 +17,7 @@ import (
 // NewActors builds the actor rankings command.
 func NewActors(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Command {
 	var period string
-	var asJSON, asJSONL, asText bool
+	var asJSON, asNDJSON bool
 	fetch := func(ctx context.Context, c *javdb.Client) ([]map[string]any, error) {
 		res, err := c.RankingsActors(ctx, period)
 		if err != nil {
@@ -50,13 +50,12 @@ func NewActors(options *invocation.RootOptions, streams *invocation.Streams) *co
 		Use:   "actors",
 		Short: "Actor rankings",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return producer.Execute(streams, asJSONL, asText, asJSON)
+			return producer.Execute(streams, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().StringVar(&period, "period", "day", "day|week|month")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }
 

--- a/internal/cli/commands/rankings/movies.go
+++ b/internal/cli/commands/rankings/movies.go
@@ -17,7 +17,7 @@ import (
 func NewMovies(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Command {
 	var type_, period string
 	var hasMagnets bool
-	var asJSON, asJSONL, asText bool
+	var asJSON, asNDJSON bool
 	producer := &pipeline.MovieListProducer{
 		Name: "rankings movies",
 		ClientFactory: func() (*javdb.Client, error) {
@@ -45,15 +45,14 @@ func NewMovies(options *invocation.RootOptions, streams *invocation.Streams) *co
 		Use:   "movies",
 		Short: "Movie rankings",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return producer.Execute(streams, asJSONL, asText, asJSON)
+			return producer.Execute(streams, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().StringVar(&type_, "type", "censored", "censored|uncensored|western|fc2")
 	cmd.Flags().StringVar(&period, "period", "day", "day|week|month")
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }
 

--- a/internal/cli/commands/rankings/movies.go
+++ b/internal/cli/commands/rankings/movies.go
@@ -53,7 +53,7 @@ func NewMovies(options *invocation.RootOptions, streams *invocation.Streams) *co
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }
 

--- a/internal/cli/commands/rankings/playback.go
+++ b/internal/cli/commands/rankings/playback.go
@@ -18,7 +18,7 @@ import (
 func NewPlayback(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Command {
 	var filterBy, period string
 	var hasMagnets bool
-	var asJSON, asJSONL, asText bool
+	var asJSON, asNDJSON bool
 	producer := &pipeline.ListProducer{
 		Name: "rankings playback",
 		ClientFactory: func() (*javdb.Client, error) {
@@ -46,15 +46,14 @@ func NewPlayback(options *invocation.RootOptions, streams *invocation.Streams) *
 		Use:   "playback",
 		Short: "Playback rankings",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return producer.Execute(streams, asJSONL, asText, asJSON)
+			return producer.Execute(streams, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().StringVar(&filterBy, "filter-by", "censored", "censored|uncensored|western|fc2")
 	cmd.Flags().StringVar(&period, "period", "day", "day|week|month")
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }
 

--- a/internal/cli/commands/rankings/playback.go
+++ b/internal/cli/commands/rankings/playback.go
@@ -54,7 +54,7 @@ func NewPlayback(options *invocation.RootOptions, streams *invocation.Streams) *
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }
 

--- a/internal/cli/commands/recent/recent.go
+++ b/internal/cli/commands/recent/recent.go
@@ -18,7 +18,7 @@ import (
 // New builds the recently viewed movies command.
 func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Command {
 	var hasMagnets bool
-	var asJSON, asJSONL, asText bool
+	var asJSON, asNDJSON bool
 	producer := &pipeline.MovieListProducer{
 		Name: "recent",
 		ClientFactory: func() (*javdb.Client, error) {
@@ -42,13 +42,12 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 		Use:   "recent",
 		Short: "List recently viewed (最近浏览) movies",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return producer.Execute(streams, asJSONL, asText, asJSON)
+			return producer.Execute(streams, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }
 

--- a/internal/cli/commands/recent/recent.go
+++ b/internal/cli/commands/recent/recent.go
@@ -48,7 +48,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }
 

--- a/internal/cli/commands/search/search.go
+++ b/internal/cli/commands/search/search.go
@@ -41,7 +41,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 		Short: "Search movies (or other dimensions with --type)",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			mode, err := pipeline.ResolveOutputMode(asJSONL, asText, asJSON, streams.InIsTerminal)
+			mode, err := pipeline.ResolveOutputMode(asJSONL, asText, asJSON)
 			if err != nil {
 				return err
 			}
@@ -86,7 +86,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop movie rows with magnets_count == 0")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	cmd.Flags().BoolVar(&asImage, "image", false, "Treat the argument as an image path or HTTP(S) URL")
 	cmd.Flags().StringVar(&source, "source", "", "Reverse-search source (default: reverse_search.default_source)")
 	cmd.Flags().BoolVar(&noCache, "no-cache", false, "Bypass the reverse-search response cache")

--- a/internal/cli/commands/search/search.go
+++ b/internal/cli/commands/search/search.go
@@ -30,8 +30,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 		filterBy, typ string
 		hasMagnets    bool
 		asJSON        bool
-		asJSONL       bool
-		asText        bool
+		asNDJSON      bool
 		asImage       bool
 		source        string
 		noCache       bool
@@ -41,7 +40,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 		Short: "Search movies (or other dimensions with --type)",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			mode, err := pipeline.ResolveOutputMode(asJSONL, asText, asJSON)
+			mode, err := pipeline.ResolveOutputMode(asNDJSON, asJSON)
 			if err != nil {
 				return err
 			}
@@ -85,8 +84,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().StringVar(&typ, "type", "", "movie|code|series|actor|maker|director|list")
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop movie rows with magnets_count == 0")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	cmd.Flags().BoolVar(&asImage, "image", false, "Treat the argument as an image path or HTTP(S) URL")
 	cmd.Flags().StringVar(&source, "source", "", "Reverse-search source (default: reverse_search.default_source)")
 	cmd.Flags().BoolVar(&noCache, "no-cache", false, "Bypass the reverse-search response cache")
@@ -95,7 +93,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 
 // classifySearchInput 一次性分类输入：返回图片模式标志与批处理输入。
 //   - --image 强制图片；参数是现有普通文件或 HTTP(S) URL 自动图片。
-//   - 无参数非 TTY stdin 按固定顺序分类（图片 magic → JSONL → 文本）。
+//   - 无参数非 TTY stdin 按固定顺序分类（图片 magic → NDJSON → 文本）。
 //   - 位置参数与非空 stdin 同时存在是歧义错误，绝不静默丢数据。
 func classifySearchInput(arg string, forced bool, reader *bufio.Reader, streams *invocation.Streams) (bool, []pipeline.Envelope, error) {
 	stdinHasContent := false
@@ -125,8 +123,8 @@ func classifySearchInput(arg string, forced bool, reader *bufio.Reader, streams 
 	switch classification {
 	case pipeline.ClassificationImage:
 		return true, nil, nil
-	case pipeline.ClassificationJSONL:
-		inputs, err := pipeline.ParseBatch(content, pipeline.KindJSONLInput)
+	case pipeline.ClassificationNDJSON:
+		inputs, err := pipeline.ParseBatch(content, pipeline.KindNDJSONInput)
 		return false, inputs, err
 	default:
 		inputs, err := pipeline.ParseBatch(content, pipeline.KindMovie)
@@ -250,8 +248,8 @@ func runImageSearch(options *invocation.RootOptions, streams *invocation.Streams
 		}); err != nil {
 			return err
 		}
-	case pipeline.OutputJSONL:
-		writer := pipeline.NewWriter(streams.Out, pipeline.OutputJSONL)
+	case pipeline.OutputNDJSON:
+		writer := pipeline.NewWriter(streams.Out, pipeline.OutputNDJSON)
 		for _, match := range result.Matches {
 			if match.Error != nil {
 				if err := writer.Write(pipeline.ErrorEnvelope(pipeline.New(pipeline.KindMovie, match.Candidate.VideoCode, match.MovieID), "search", "link", match.Error.Code, match.Error.Message)); err != nil {

--- a/internal/cli/commands/search/search_image_test.go
+++ b/internal/cli/commands/search/search_image_test.go
@@ -138,7 +138,7 @@ func TestSearchImageExplicitFlagAndJSON(t *testing.T) {
 	}
 }
 
-func TestSearchImageFromStdinMagic(t *testing.T) {
+func TestSearchImageFromStdinMagicDefaultsToText(t *testing.T) {
 	provider, javdbServer := imageSearchFixture(t)
 	defer provider.Close()
 	defer javdbServer.Close()
@@ -150,12 +150,15 @@ func TestSearchImageFromStdinMagic(t *testing.T) {
 		t.Fatal("partial failure must exit non-zero")
 	}
 	out := streams.Out.(*bytes.Buffer).String()
-	// 非 TTY 管道默认 JSONL 信封；成功项 movie 信封、失败项 error 信封。
-	if !strings.Contains(out, `"kind":"movie"`) || !strings.Contains(out, "SSIS-589") {
-		t.Errorf("stdin image JSONL output lacks movie envelope:\n%s", out)
+	// 管道只负责输入分类，未显式指定结构化输出时仍使用纯文本。
+	if !strings.Contains(out, "SSIS-589") || !strings.Contains(out, "95.2%") {
+		t.Errorf("stdin image text output lacks candidate:\n%s", out)
 	}
-	if !strings.Contains(out, `"kind":"error"`) {
-		t.Errorf("stdin image JSONL output lacks error envelope:\n%s", out)
+	if !strings.Contains(out, "GHOST-999") || !strings.Contains(out, "失败") {
+		t.Errorf("stdin image text output lacks failure:\n%s", out)
+	}
+	if strings.Contains(out, `"kind":`) {
+		t.Errorf("stdin image unexpectedly emitted JSONL without --jsonl:\n%s", out)
 	}
 }
 

--- a/internal/cli/commands/search/search_image_test.go
+++ b/internal/cli/commands/search/search_image_test.go
@@ -158,7 +158,7 @@ func TestSearchImageFromStdinMagicDefaultsToText(t *testing.T) {
 		t.Errorf("stdin image text output lacks failure:\n%s", out)
 	}
 	if strings.Contains(out, `"kind":`) {
-		t.Errorf("stdin image unexpectedly emitted JSONL without --jsonl:\n%s", out)
+		t.Errorf("stdin image unexpectedly emitted NDJSON without --ndjson:\n%s", out)
 	}
 }
 

--- a/internal/cli/commands/search/search_pipeline_test.go
+++ b/internal/cli/commands/search/search_pipeline_test.go
@@ -39,8 +39,8 @@ func TestSearchTextStdinBatchConsumesKeywords(t *testing.T) {
 	}
 }
 
-// TestSearchJSONLBatchRejectsWrongKind JSONL 批处理：不兼容 kind 原位错误。
-func TestSearchJSONLBatchRejectsWrongKind(t *testing.T) {
+// TestSearchNDJSONBatchRejectsWrongKind NDJSON 批处理：不兼容 kind 原位错误。
+func TestSearchNDJSONBatchRejectsWrongKind(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("USERPROFILE", t.TempDir())
 	t.Setenv("HOMEDRIVE", filepath.VolumeName(t.TempDir()))
@@ -52,7 +52,7 @@ func TestSearchJSONLBatchRejectsWrongKind(t *testing.T) {
 
 	streams := invocation.NewStreams(strings.NewReader("{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"actor\",\"ref\":\"x\"}\n"), &bytes.Buffer{}, &bytes.Buffer{})
 	cmd := New(&invocation.RootOptions{Host: server.URL}, streams)
-	cmd.SetArgs([]string{"--jsonl"})
+	cmd.SetArgs([]string{"--ndjson"})
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "1 of 1 items failed") {
 		t.Fatalf("expected batch failure, got %v", err)

--- a/internal/cli/commands/search/search_pipeline_test.go
+++ b/internal/cli/commands/search/search_pipeline_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // TestSearchTextStdinBatchConsumesKeywords 文本 stdin 批处理：逐关键词搜索并
-// 输出 movie 信封，顺序保持。
+// 默认输出纯文本，顺序保持。
 func TestSearchTextStdinBatchConsumesKeywords(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("USERPROFILE", t.TempDir())
@@ -34,20 +34,8 @@ func TestSearchTextStdinBatchConsumesKeywords(t *testing.T) {
 		t.Fatalf("execute: %v", err)
 	}
 	out := streams.Out.(*bytes.Buffer).String()
-	lines := strings.Split(strings.TrimSpace(out), "\n")
-	if len(lines) != 2 {
-		t.Fatalf("envelope lines = %d:\n%s", len(lines), out)
-	}
-	var first struct {
-		Kind string `json:"kind"`
-		Ref  string `json:"ref"`
-		ID   string `json:"id"`
-	}
-	if err := json.Unmarshal([]byte(lines[0]), &first); err != nil {
-		t.Fatal(err)
-	}
-	if first.Kind != "movie" || first.Ref != "ssis-589" || first.ID != "id-ssis-589" {
-		t.Errorf("first envelope = %+v", first)
+	if out != "ssis-589\nhzgd-246\n" {
+		t.Errorf("default pipeline output = %q, want plain input refs", out)
 	}
 }
 
@@ -64,7 +52,7 @@ func TestSearchJSONLBatchRejectsWrongKind(t *testing.T) {
 
 	streams := invocation.NewStreams(strings.NewReader("{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"actor\",\"ref\":\"x\"}\n"), &bytes.Buffer{}, &bytes.Buffer{})
 	cmd := New(&invocation.RootOptions{Host: server.URL}, streams)
-	cmd.SetArgs([]string{})
+	cmd.SetArgs([]string{"--jsonl"})
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "1 of 1 items failed") {
 		t.Fatalf("expected batch failure, got %v", err)

--- a/internal/cli/commands/tags/tags.go
+++ b/internal/cli/commands/tags/tags.go
@@ -18,7 +18,7 @@ import (
 func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Command {
 	var zone string
 	var refresh bool
-	var asJSON, asJSONL, asText bool
+	var asJSON, asNDJSON bool
 	producer := &pipeline.Producer{
 		Name: "tags",
 		Produce: func(ctx context.Context) ([]pipeline.Envelope, error) {
@@ -96,13 +96,12 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 		Use:   "tags",
 		Short: "List content-tag taxonomy (id + EN + 中文)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return producer.Execute(streams, asJSONL, asText, asJSON)
+			return producer.Execute(streams, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().StringVar(&zone, "zone", "censored", "censored|uncensored|western|fc2")
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Re-fetch from API and rewrite local JSON")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }

--- a/internal/cli/commands/tags/tags.go
+++ b/internal/cli/commands/tags/tags.go
@@ -103,6 +103,6 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Re-fetch from API and rewrite local JSON")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }

--- a/internal/cli/commands/top250/top250.go
+++ b/internal/cli/commands/top250/top250.go
@@ -21,7 +21,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	var zone, year string
 	var startRank, page, limit int
 	var ignoreWatched, hasMagnets bool
-	var asJSON, asJSONL, asText bool
+	var asJSON, asNDJSON bool
 	var generatedAt string
 	producer := &pipeline.MovieListProducer{
 		Name: "top250",
@@ -57,7 +57,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 		Use:   "top250",
 		Short: "TOP250 list (needs login)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return producer.Execute(streams, asJSONL, asText, asJSON)
+			return producer.Execute(streams, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().StringVar(&zone, "zone", "", "censored|uncensored|western|fc2 (omit for all-site)")
@@ -68,8 +68,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().BoolVar(&ignoreWatched, "ignore-watched", false, "Skip already watched titles")
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }
 

--- a/internal/cli/commands/top250/top250.go
+++ b/internal/cli/commands/top250/top250.go
@@ -69,7 +69,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }
 

--- a/internal/cli/commands/unmark/unmark.go
+++ b/internal/cli/commands/unmark/unmark.go
@@ -73,6 +73,6 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().BoolVarP(&isID, "id", "i", false, "Treat NUMBER as internal movie id")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }

--- a/internal/cli/commands/unmark/unmark.go
+++ b/internal/cli/commands/unmark/unmark.go
@@ -16,7 +16,7 @@ import (
 // New builds the unmark command.
 func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Command {
 	var isID bool
-	var asJSON, asJSONL, asText bool
+	var asJSON, asNDJSON bool
 	fetch := func(c *javdb.Client, ctx context.Context, ref string, useID bool) (string, bool, error) {
 		mid := ref
 		var err error
@@ -67,12 +67,11 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 		Short: "Remove watched/want mark for a movie",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runner.Execute(streams, args, asJSONL, asText, asJSON)
+			return runner.Execute(streams, args, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().BoolVarP(&isID, "id", "i", false, "Treat NUMBER as internal movie id")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }

--- a/internal/cli/commands/want/want.go
+++ b/internal/cli/commands/want/want.go
@@ -48,7 +48,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }
 

--- a/internal/cli/commands/want/want.go
+++ b/internal/cli/commands/want/want.go
@@ -18,7 +18,7 @@ import (
 // New builds the want-to-watch movies command.
 func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Command {
 	var hasMagnets bool
-	var asJSON, asJSONL, asText bool
+	var asJSON, asNDJSON bool
 	producer := &pipeline.MovieListProducer{
 		Name: "want",
 		ClientFactory: func() (*javdb.Client, error) {
@@ -42,13 +42,12 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 		Use:   "want",
 		Short: "List want-to-watch (想看) movies",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return producer.Execute(streams, asJSONL, asText, asJSON)
+			return producer.Execute(streams, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }
 

--- a/internal/cli/commands/watched/watched.go
+++ b/internal/cli/commands/watched/watched.go
@@ -48,7 +48,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }
 

--- a/internal/cli/commands/watched/watched.go
+++ b/internal/cli/commands/watched/watched.go
@@ -18,7 +18,7 @@ import (
 // New builds the watched movies command.
 func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Command {
 	var hasMagnets bool
-	var asJSON, asJSONL, asText bool
+	var asJSON, asNDJSON bool
 	producer := &pipeline.MovieListProducer{
 		Name: "watched",
 		ClientFactory: func() (*javdb.Client, error) {
@@ -42,13 +42,12 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 		Use:   "watched",
 		Short: "List watched (看過) movies",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return producer.Execute(streams, asJSONL, asText, asJSON)
+			return producer.Execute(streams, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }
 

--- a/internal/cli/commands/watched/watched_pipeline_test.go
+++ b/internal/cli/commands/watched/watched_pipeline_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/FlanChanXwO/javdb-cli/internal/cli/invocation"
 )
 
-// TestWatchedProducerJSONL 非 TTY producer：不消费 stdin，输出逐条 movie
-// 信封；TTY 保持人类文本行。
+// TestWatchedProducerJSONL 显式 JSONL producer：不消费 stdin，输出逐条 movie
+// 信封。
 func TestWatchedProducerJSONL(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("USERPROFILE", t.TempDir())
@@ -31,7 +31,7 @@ func TestWatchedProducerJSONL(t *testing.T) {
 
 	streams := invocation.NewStreams(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
 	cmd := New(&invocation.RootOptions{Host: server.URL}, streams)
-	cmd.SetArgs([]string{})
+	cmd.SetArgs([]string{"--jsonl"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
 	}

--- a/internal/cli/commands/watched/watched_pipeline_test.go
+++ b/internal/cli/commands/watched/watched_pipeline_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/FlanChanXwO/javdb-cli/internal/cli/invocation"
 )
 
-// TestWatchedProducerJSONL 显式 JSONL producer：不消费 stdin，输出逐条 movie
+// TestWatchedProducerNDJSON 显式 NDJSON producer：不消费 stdin，输出逐条 movie
 // 信封。
-func TestWatchedProducerJSONL(t *testing.T) {
+func TestWatchedProducerNDJSON(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("USERPROFILE", t.TempDir())
 	t.Setenv("HOMEDRIVE", filepath.VolumeName(t.TempDir()))
@@ -31,14 +31,14 @@ func TestWatchedProducerJSONL(t *testing.T) {
 
 	streams := invocation.NewStreams(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
 	cmd := New(&invocation.RootOptions{Host: server.URL}, streams)
-	cmd.SetArgs([]string{"--jsonl"})
+	cmd.SetArgs([]string{"--ndjson"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
 	out := streams.Out.(*bytes.Buffer).String()
 	lines := strings.Split(strings.TrimSpace(out), "\n")
 	if len(lines) != 2 {
-		t.Fatalf("jsonl lines = %d:\n%s", len(lines), out)
+		t.Fatalf("ndjson lines = %d:\n%s", len(lines), out)
 	}
 	var first struct {
 		Kind string `json:"kind"`

--- a/internal/cli/entity/entitycmd/entitycmd.go
+++ b/internal/cli/entity/entitycmd/entitycmd.go
@@ -20,12 +20,12 @@ import (
 // New 构造实体影片列表命令（actor/series/maker/director/code/list 共用）。
 func New(kind, use, short string, options *invocation.RootOptions, streams *invocation.Streams) *cobra.Command {
 	var (
-		zone, sort, order       string
-		page, limit             int
-		tagRefs, main           []string
-		allPages                bool
-		hasMagnets              bool
-		asJSON, asJSONL, asText bool
+		zone, sort, order string
+		page, limit       int
+		tagRefs, main     []string
+		allPages          bool
+		hasMagnets        bool
+		asJSON, asNDJSON  bool
 	)
 	pipelineKind := pipeline.Kind(kind)
 	runner := &pipeline.BatchRunner{
@@ -73,7 +73,7 @@ func New(kind, use, short string, options *invocation.RootOptions, streams *invo
 		Short: short,
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runner.Execute(streams, args, asJSONL, asText, asJSON)
+			return runner.Execute(streams, args, asNDJSON, asJSON)
 		},
 	}
 	cmd.Flags().StringVar(&zone, "zone", "censored", "censored|uncensored|western|fc2")
@@ -86,8 +86,7 @@ func New(kind, use, short string, options *invocation.RootOptions, streams *invo
 	cmd.Flags().BoolVar(&allPages, "all", false, "Fetch all pages (capped)")
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "JSON with entity meta + movies")
-	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
+	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
 }
 

--- a/internal/cli/entity/entitycmd/entitycmd.go
+++ b/internal/cli/entity/entitycmd/entitycmd.go
@@ -87,7 +87,7 @@ func New(kind, use, short string, options *invocation.RootOptions, streams *invo
 	cmd.Flags().BoolVar(&hasMagnets, "has-magnets", false, "Drop magnets_count==0")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "JSON with entity meta + movies")
 	cmd.Flags().BoolVar(&asJSONL, "jsonl", false, "Pipeline JSONL envelopes")
-	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default for TTY)")
+	cmd.Flags().BoolVar(&asText, "text", false, "Plain text lines (default)")
 	return cmd
 }
 

--- a/internal/cli/pipeline/classify.go
+++ b/internal/cli/pipeline/classify.go
@@ -18,14 +18,14 @@ type Classification int
 const (
 	// ClassificationImage 表示 JPEG/PNG/WEBP 图片字节。
 	ClassificationImage Classification = iota
-	// ClassificationJSONL 表示 javdb.pipeline/v1 信封流。
-	ClassificationJSONL
+	// ClassificationNDJSON 表示 javdb.pipeline/v1 信封流。
+	ClassificationNDJSON
 	// ClassificationText 表示逐行纯文本 ref。
 	ClassificationText
 )
 
-// Classify 按固定顺序识别 stdin 类别：图片 magic → JSONL → 文本。
-// 不消费输入：图片判定只 Peek 前 12 字节；JSONL/文本判定读取全部剩余内容。
+// Classify 按固定顺序识别 stdin 类别：图片 magic → NDJSON → 文本。
+// 不消费输入：图片判定只 Peek 前 12 字节；NDJSON/文本判定读取全部剩余内容。
 func Classify(reader *bufio.Reader) (Classification, []byte, error) {
 	if reader == nil {
 		return ClassificationText, nil, nil
@@ -41,14 +41,14 @@ func Classify(reader *bufio.Reader) (Classification, []byte, error) {
 	if err != nil {
 		return ClassificationText, nil, fmt.Errorf("read stdin: %w", err)
 	}
-	if looksLikeJSONL(content) {
-		return ClassificationJSONL, content, nil
+	if looksLikeNDJSON(content) {
+		return ClassificationNDJSON, content, nil
 	}
 	return ClassificationText, content, nil
 }
 
-// looksLikeJSONL 判定首个非空行是否为合法 v1 信封。
-func looksLikeJSONL(content []byte) bool {
+// looksLikeNDJSON 判定首个非空行是否为合法 v1 信封。
+func looksLikeNDJSON(content []byte) bool {
 	for _, line := range bytes.Split(content, []byte("\n")) {
 		trimmed := strings.TrimSpace(string(line))
 		if trimmed == "" {

--- a/internal/cli/pipeline/consumer.go
+++ b/internal/cli/pipeline/consumer.go
@@ -16,7 +16,7 @@ const KindTag Kind = "tag"
 // Consumer 把只读命令的单项执行包装成统一输入/输出管道：
 //   - 输入：位置参数或非 TTY stdin（分类：图片 magic → JSONL → 文本）。
 //   - 消费者严格检查 kind，不兼容输入生成原位错误信封。
-//   - 输出：TTY 人类文本、非 TTY JSONL；--jsonl/--text/--json 互斥。
+//   - 输出：默认文本；显式 --jsonl/--text/--json 互斥。
 //   - 显式 --json：单项走 LegacyJSON 既有 shape，多项输出信封数组。
 type Consumer struct {
 	Name string
@@ -32,7 +32,7 @@ type Consumer struct {
 
 // Execute 是命令 RunE 的通用实现（不消费图片；需要图片输入的调用方自行先行处理）。
 func (c *Consumer) Execute(streams *invocation.Streams, args []string, jsonl, text, json bool) error {
-	mode, err := ResolveOutputMode(jsonl, text, json, streams.InIsTerminal)
+	mode, err := ResolveOutputMode(jsonl, text, json)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/pipeline/consumer.go
+++ b/internal/cli/pipeline/consumer.go
@@ -14,9 +14,9 @@ import (
 const KindTag Kind = "tag"
 
 // Consumer 把只读命令的单项执行包装成统一输入/输出管道：
-//   - 输入：位置参数或非 TTY stdin（分类：图片 magic → JSONL → 文本）。
+//   - 输入：位置参数或非 TTY stdin（分类：图片 magic → NDJSON → 文本）。
 //   - 消费者严格检查 kind，不兼容输入生成原位错误信封。
-//   - 输出：默认文本；显式 --jsonl/--text/--json 互斥。
+//   - 输出：默认文本；显式 --ndjson/--json 互斥。
 //   - 显式 --json：单项走 LegacyJSON 既有 shape，多项输出信封数组。
 type Consumer struct {
 	Name string
@@ -24,15 +24,15 @@ type Consumer struct {
 	AcceptedKinds []Kind
 	// RunOne 执行单项并返回输出信封。
 	RunOne func(context.Context, Envelope) (Envelope, error)
-	// RenderText 输出人类文本（TTY/--text）。
+	// RenderText 输出默认的人类文本。
 	RenderText func(io.Writer, Envelope) error
 	// LegacyJSON 输出单项显式 --json 的既有 shape；nil 时输出信封对象。
 	LegacyJSON func(io.Writer, Envelope) error
 }
 
 // Execute 是命令 RunE 的通用实现（不消费图片；需要图片输入的调用方自行先行处理）。
-func (c *Consumer) Execute(streams *invocation.Streams, args []string, jsonl, text, json bool) error {
-	mode, err := ResolveOutputMode(jsonl, text, json)
+func (c *Consumer) Execute(streams *invocation.Streams, args []string, ndjson, json bool) error {
+	mode, err := ResolveOutputMode(ndjson, json)
 	if err != nil {
 		return err
 	}
@@ -54,7 +54,7 @@ func (c *Consumer) Execute(streams *invocation.Streams, args []string, jsonl, te
 // RunInputs 按输出模式处理已收集的输入；单项失败原位错误信封并继续。
 // 调用方（如 search）可自行完成图片分类后复用本方法。
 func (c *Consumer) RunInputs(streams *invocation.Streams, inputs []Envelope, mode OutputMode) error {
-	// legacy JSON shape 只适用于纯文本 ref 输入；JSONL 信封先过 kind 校验。
+	// legacy JSON shape 只适用于纯文本 ref 输入；NDJSON 信封先过 kind 校验。
 	if mode == OutputJSON && len(inputs) == 1 && inputs[0].Kind == "" && c.LegacyJSON != nil {
 		output, err := c.RunOne(context.Background(), inputs[0])
 		if err != nil {
@@ -97,7 +97,7 @@ func (c *Consumer) RunInputs(streams *invocation.Streams, inputs []Envelope, mod
 
 // CollectInputs 统一收集输入：位置参数（单个）或非 TTY stdin 批。
 // 位置参数与非空 stdin 同时存在是歧义错误。stdin 按固定顺序分类
-// （图片 magic → JSONL → 文本）；图片输入显式报错（调用方先行处理）。
+// （图片 magic → NDJSON → 文本）；图片输入显式报错（调用方先行处理）。
 func CollectInputs(reader *bufio.Reader, streams *invocation.Streams, arg string, textKinds []Kind) ([]Envelope, error) {
 	stdinHasContent := false
 	if !streams.InIsTerminal {
@@ -123,8 +123,8 @@ func CollectInputs(reader *bufio.Reader, streams *invocation.Streams, arg string
 	switch classification {
 	case ClassificationImage:
 		return nil, fmt.Errorf("stdin is an image; this command does not accept image input")
-	case ClassificationJSONL:
-		return ParseBatch(content, KindJSONLInput)
+	case ClassificationNDJSON:
+		return ParseBatch(content, KindNDJSONInput)
 	default:
 		kind := KindMovie
 		if len(textKinds) == 1 {

--- a/internal/cli/pipeline/consumer_test.go
+++ b/internal/cli/pipeline/consumer_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -135,7 +136,7 @@ func TestConsumerSingleJSONLegacyShape(t *testing.T) {
 	}
 }
 
-func TestListProducerJSONLOutput(t *testing.T) {
+func TestListProducerDefaultsToText(t *testing.T) {
 	streams, out := testStreams("", false)
 	producer := &ListProducer{
 		Name: "watched",
@@ -151,20 +152,40 @@ func TestListProducerJSONLOutput(t *testing.T) {
 		JSON: func(items []map[string]any) (map[string]any, error) {
 			return map[string]any{"movies": items}, nil
 		},
+		RowText: func(w io.Writer, _ io.Writer, items []map[string]any) error {
+			for _, item := range items {
+				if _, err := fmt.Fprintln(w, item["number"]); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
 	}
 	if err := producer.Execute(streams, false, false, false); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
-	if len(lines) != 2 {
-		t.Fatalf("jsonl lines = %d", len(lines))
+	if out.String() != "SSIS-589\nHZGD-246\n" {
+		t.Errorf("default output = %q", out.String())
 	}
-	var first Envelope
-	if err := json.Unmarshal([]byte(lines[0]), &first); err != nil {
-		t.Fatal(err)
+}
+
+func TestBatchRunnerPipedInputDefaultsToText(t *testing.T) {
+	streams, out := testStreams("SSIS-589\nHZGD-246\n", false)
+	runner := &BatchRunner{
+		Name:  "search",
+		Kinds: []Kind{KindMovie},
+		RunOne: func(_ *javdb.Client, _ context.Context, input Envelope) (Envelope, error) {
+			return New(KindMovie, input.Ref, "id-"+input.Ref), nil
+		},
+		Legacy: func([]string) error {
+			return testError("batch input must not use the single-item legacy path")
+		},
 	}
-	if first.Kind != KindMovie || first.Ref != "SSIS-589" || first.ID != "id-a" {
-		t.Errorf("envelope = %+v", first)
+	if err := runner.Execute(streams, nil, false, false, false); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out.String() != "SSIS-589\nHZGD-246\n" {
+		t.Errorf("default output = %q", out.String())
 	}
 }
 

--- a/internal/cli/pipeline/consumer_test.go
+++ b/internal/cli/pipeline/consumer_test.go
@@ -34,8 +34,8 @@ func TestCollectInputsMatrix(t *testing.T) {
 		{name: "positional arg", stdin: "", terminal: true, arg: "SSIS-589", want: 1, wantKind: ""},
 		{name: "tty no input", stdin: "", terminal: true, arg: "", want: 0},
 		{name: "text batch", stdin: "SSIS-589\nHZGD-246\n", terminal: false, arg: "", want: 2, wantKind: KindMovie},
-		{name: "jsonl batch", stdin: "{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"movie\",\"ref\":\"a\"}\n{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"movie\",\"ref\":\"b\"}\n", terminal: false, arg: "", want: 2, wantKind: KindMovie},
-		{name: "jsonl wrong kind", stdin: "{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"actor\",\"ref\":\"a\"}\n", terminal: false, arg: "", want: 1, wantKind: KindActor},
+		{name: "ndjson batch", stdin: "{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"movie\",\"ref\":\"a\"}\n{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"movie\",\"ref\":\"b\"}\n", terminal: false, arg: "", want: 2, wantKind: KindMovie},
+		{name: "ndjson wrong kind", stdin: "{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"actor\",\"ref\":\"a\"}\n", terminal: false, arg: "", want: 1, wantKind: KindActor},
 		{name: "ambiguous arg and stdin", stdin: "data\n", terminal: false, arg: "x", wantErr: true},
 		{name: "image rejected", stdin: string([]byte{0xFF, 0xD8, 0xFF}), terminal: false, arg: "", wantErr: true},
 	} {
@@ -81,7 +81,7 @@ func TestConsumerKindCheckingAndInPlaceErrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CollectInputs: %v", err)
 	}
-	err = consumer.RunInputs(streams, inputs, OutputJSONL)
+	err = consumer.RunInputs(streams, inputs, OutputNDJSON)
 	if err == nil || !strings.Contains(err.Error(), "2 of 3 items failed") {
 		t.Fatalf("expected 2-of-3 failure summary, got %v", err)
 	}
@@ -108,7 +108,7 @@ func TestConsumerKindCheckingAndInPlaceErrors(t *testing.T) {
 	}
 }
 
-func TestConsumerSingleJSONLegacyShape(t *testing.T) {
+func TestConsumerSingleNDJSONLegacyShape(t *testing.T) {
 	streams, out := testStreams("", true)
 	legacyCalled := false
 	consumer := &Consumer{
@@ -161,7 +161,7 @@ func TestListProducerDefaultsToText(t *testing.T) {
 			return nil
 		},
 	}
-	if err := producer.Execute(streams, false, false, false); err != nil {
+	if err := producer.Execute(streams, false, false); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 	if out.String() != "SSIS-589\nHZGD-246\n" {
@@ -181,7 +181,7 @@ func TestBatchRunnerPipedInputDefaultsToText(t *testing.T) {
 			return testError("batch input must not use the single-item legacy path")
 		},
 	}
-	if err := runner.Execute(streams, nil, false, false, false); err != nil {
+	if err := runner.Execute(streams, nil, false, false); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 	if out.String() != "SSIS-589\nHZGD-246\n" {
@@ -189,10 +189,9 @@ func TestBatchRunnerPipedInputDefaultsToText(t *testing.T) {
 	}
 }
 
-// TestConsumerSingleJSONLEnvelopeStillChecksKind 单条 JSONL 信封在显式
-// --text/--json 下也必须经过 kind 校验，且保留 id 语义（legacy 路径只
-// 服务于纯文本 ref 输入）。
-func TestConsumerSingleJSONLEnvelopeStillChecksKind(t *testing.T) {
+// TestConsumerSingleNDJSONEnvelopeStillChecksKind 单条 NDJSON 信封必须经过
+// kind 校验并保留 id 语义（legacy 路径只服务于纯文本 ref 输入）。
+func TestConsumerSingleNDJSONEnvelopeStillChecksKind(t *testing.T) {
 	streams, out := testStreams("", false)
 	consumer := &Consumer{
 		Name:          "detail",
@@ -205,7 +204,7 @@ func TestConsumerSingleJSONLEnvelopeStillChecksKind(t *testing.T) {
 			return New(KindMovie, input.Ref, input.ID).WithData(map[string]any{"movie_id": input.ID}), nil
 		},
 		LegacyJSON: func(w io.Writer, envelope Envelope) error {
-			return testError("legacy JSON must not run for JSONL envelopes")
+			return testError("legacy JSON must not run for NDJSON envelopes")
 		},
 	}
 	// 显式 --json 单条 actor 信封 → kind 校验失败（原位 error），不落 legacy。
@@ -218,7 +217,7 @@ func TestConsumerSingleJSONLEnvelopeStillChecksKind(t *testing.T) {
 		t.Errorf("kind error envelope missing: %s", out.String())
 	}
 
-	// 单条 movie 信封（带 id）+ --text → 走 RunOne 并保留 id。
+	// 单条 movie 信封（带 id）+ 默认文本 → 走 RunOne 并保留 id。
 	streams2, out2 := testStreams("", false)
 	consumer2 := &Consumer{
 		Name:          "detail",
@@ -231,7 +230,7 @@ func TestConsumerSingleJSONLEnvelopeStillChecksKind(t *testing.T) {
 	if err := consumer2.RunInputs(streams2, movieInputs, OutputText); err != nil {
 		t.Fatalf("RunInputs text: %v", err)
 	}
-	// --text 输出使用人类稳定引用（ref）；消费侧（RunOne）保留 id 语义。
+	// 默认文本输出使用人类稳定引用（ref）；消费侧（RunOne）保留 id 语义。
 	if strings.TrimSpace(out2.String()) != "SSIS-589" {
 		t.Errorf("text output = %q, want ref SSIS-589", out2.String())
 	}

--- a/internal/cli/pipeline/envelope.go
+++ b/internal/cli/pipeline/envelope.go
@@ -2,8 +2,7 @@
 // 严格 JSONL/文本解码、输入分类与输出模式。
 //
 // 命令之间通过 JSONL 组合：生产者按固定 schema 输出逐条 envelope，消费者按
-// kind 选择 id 或 ref。TTY 默认人类文本，非 TTY 默认 JSONL；显式 --jsonl /
-// --text / --json 互斥。
+// kind 选择 id 或 ref。默认输出文本；显式 --jsonl / --text / --json 互斥。
 package pipeline
 
 import (

--- a/internal/cli/pipeline/envelope.go
+++ b/internal/cli/pipeline/envelope.go
@@ -1,8 +1,8 @@
 // Package pipeline 实现 javdb.pipeline/v1 机器协议核心：typed envelope、
-// 严格 JSONL/文本解码、输入分类与输出模式。
+// 严格 NDJSON/文本解码、输入分类与输出模式。
 //
-// 命令之间通过 JSONL 组合：生产者按固定 schema 输出逐条 envelope，消费者按
-// kind 选择 id 或 ref。默认输出文本；显式 --jsonl / --text / --json 互斥。
+// 命令之间通过 NDJSON 组合：生产者按固定 schema 输出逐条 envelope，消费者按
+// kind 选择 id 或 ref。默认输出文本；显式 --ndjson / --json 互斥。
 package pipeline
 
 import (
@@ -105,8 +105,8 @@ func IsKind(kind Kind) bool {
 	}
 }
 
-// DecodeJSONL 严格解码一条 JSONL 记录；拒绝非对象行、尾随数据与非法信封。
-func DecodeJSONL(line string) (Envelope, error) {
+// DecodeNDJSON 严格解码一条 NDJSON 记录；拒绝非对象行、尾随数据与非法信封。
+func DecodeNDJSON(line string) (Envelope, error) {
 	trimmed := strings.TrimSpace(line)
 	if trimmed == "" {
 		return Envelope{}, errEmptyLine()
@@ -135,8 +135,8 @@ func DecodeText(line string) (Envelope, error) {
 }
 
 // ParseBatch 把 stdin 内容按分类解码为信封序列：
-//   - 输入分类固定顺序为图片 magic、JSONL、文本（由 Classify 完成）；
-//   - JSONL 模式逐行严格解码，混合/非法行返回带行号的错误；
+//   - 输入分类固定顺序为图片 magic、NDJSON、文本（由 Classify 完成）；
+//   - NDJSON 模式逐行严格解码，混合/非法行返回带行号的错误；
 //   - 文本模式逐行转 ref。
 func ParseBatch(content []byte, kind Kind) ([]Envelope, error) {
 	lines := strings.Split(string(content), "\n")
@@ -148,8 +148,8 @@ func ParseBatch(content []byte, kind Kind) ([]Envelope, error) {
 		var envelope Envelope
 		var err error
 		switch kind {
-		case KindJSONLInput:
-			envelope, err = DecodeJSONL(line)
+		case KindNDJSONInput:
+			envelope, err = DecodeNDJSON(line)
 		default:
 			envelope, err = DecodeText(line)
 			if err == nil {
@@ -164,8 +164,8 @@ func ParseBatch(content []byte, kind Kind) ([]Envelope, error) {
 	return envelopes, nil
 }
 
-// KindJSONLInput 是 ParseBatch 的哨兵：表示逐行 JSONL 严格解码。
-const KindJSONLInput Kind = "jsonl"
+// KindNDJSONInput 是 ParseBatch 的哨兵：表示逐行 NDJSON 严格解码。
+const KindNDJSONInput Kind = "ndjson"
 
 func errEmptyLine() error {
 	return errors.New("empty line")

--- a/internal/cli/pipeline/output.go
+++ b/internal/cli/pipeline/output.go
@@ -17,28 +17,20 @@ const (
 	OutputAuto OutputMode = iota
 	// OutputText 强制逐行 ref 文本。
 	OutputText
-	// OutputJSONL 强制逐条信封 JSONL。
-	OutputJSONL
+	// OutputNDJSON 强制逐条信封 NDJSON。
+	OutputNDJSON
 	// OutputJSON 显式 --json：单项保持命令既有形状，多项输出 JSON 数组。
 	OutputJSON
 )
 
 // ResolveOutputMode 校验互斥并解析输出模式；未显式指定时保持人类文本。
-func ResolveOutputMode(flagJSONL, flagText, flagJSON bool) (OutputMode, error) {
-	explicit := 0
-	for _, set := range []bool{flagJSONL, flagText, flagJSON} {
-		if set {
-			explicit++
-		}
-	}
-	if explicit > 1 {
-		return OutputAuto, errors.New("--jsonl, --text and --json are mutually exclusive")
+func ResolveOutputMode(flagNDJSON, flagJSON bool) (OutputMode, error) {
+	if flagNDJSON && flagJSON {
+		return OutputAuto, errors.New("--ndjson and --json are mutually exclusive")
 	}
 	switch {
-	case flagJSONL:
-		return OutputJSONL, nil
-	case flagText:
-		return OutputText, nil
+	case flagNDJSON:
+		return OutputNDJSON, nil
 	case flagJSON:
 		return OutputJSON, nil
 	default:
@@ -51,15 +43,15 @@ func ResolveOutputMode(flagJSONL, flagText, flagJSON bool) (OutputMode, error) {
 type Writer struct {
 	mode     OutputMode
 	out      io.Writer
-	jsonl    *json.Encoder
+	ndjson   *json.Encoder
 	buffered []Envelope
 }
 
 // NewWriter 构造按 mode 输出的 writer。
 func NewWriter(out io.Writer, mode OutputMode) *Writer {
 	writer := &Writer{mode: mode, out: out}
-	if mode == OutputJSONL {
-		writer.jsonl = json.NewEncoder(out)
+	if mode == OutputNDJSON {
+		writer.ndjson = json.NewEncoder(out)
 	}
 	return writer
 }
@@ -78,8 +70,8 @@ func (w *Writer) Write(envelope Envelope) error {
 		return nil
 	}
 	switch w.mode {
-	case OutputJSONL:
-		return w.jsonl.Encode(envelope)
+	case OutputNDJSON:
+		return w.ndjson.Encode(envelope)
 	case OutputText:
 		ref := envelope.Ref
 		if ref == "" {

--- a/internal/cli/pipeline/output.go
+++ b/internal/cli/pipeline/output.go
@@ -9,11 +9,11 @@ import (
 	"github.com/FlanChanXwO/javdb-cli/internal/common/jsonx"
 )
 
-// OutputMode 是命令的机器输出格式。
+// OutputMode 是命令的输出格式。
 type OutputMode int
 
 const (
-	// OutputAuto 由 TTY 状态决定：TTY 人类文本，非 TTY JSONL。
+	// OutputAuto 表示尚未解析显式输出 flag。
 	OutputAuto OutputMode = iota
 	// OutputText 强制逐行 ref 文本。
 	OutputText
@@ -23,8 +23,8 @@ const (
 	OutputJSON
 )
 
-// ResolveOutputMode 校验互斥并解析输出模式；未显式指定时按 TTY 状态默认。
-func ResolveOutputMode(flagJSONL, flagText, flagJSON bool, isTerminal bool) (OutputMode, error) {
+// ResolveOutputMode 校验互斥并解析输出模式；未显式指定时保持人类文本。
+func ResolveOutputMode(flagJSONL, flagText, flagJSON bool) (OutputMode, error) {
 	explicit := 0
 	for _, set := range []bool{flagJSONL, flagText, flagJSON} {
 		if set {
@@ -41,10 +41,8 @@ func ResolveOutputMode(flagJSONL, flagText, flagJSON bool, isTerminal bool) (Out
 		return OutputText, nil
 	case flagJSON:
 		return OutputJSON, nil
-	case isTerminal:
-		return OutputText, nil
 	default:
-		return OutputJSONL, nil
+		return OutputText, nil
 	}
 }
 

--- a/internal/cli/pipeline/pipeline_test.go
+++ b/internal/cli/pipeline/pipeline_test.go
@@ -128,20 +128,18 @@ func TestResolveOutputMode(t *testing.T) {
 		jsonl     bool
 		text      bool
 		json      bool
-		terminal  bool
 		want      OutputMode
 		wantError bool
 	}{
-		{name: "default tty", terminal: true, want: OutputText},
-		{name: "default pipe", terminal: false, want: OutputJSONL},
-		{name: "explicit jsonl", jsonl: true, terminal: true, want: OutputJSONL},
-		{name: "explicit text", text: true, terminal: false, want: OutputText},
-		{name: "explicit json", json: true, terminal: false, want: OutputJSON},
+		{name: "default", want: OutputText},
+		{name: "explicit jsonl", jsonl: true, want: OutputJSONL},
+		{name: "explicit text", text: true, want: OutputText},
+		{name: "explicit json", json: true, want: OutputJSON},
 		{name: "jsonl and json", jsonl: true, json: true, wantError: true},
 		{name: "all three", jsonl: true, text: true, json: true, wantError: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			mode, err := ResolveOutputMode(tc.jsonl, tc.text, tc.json, tc.terminal)
+			mode, err := ResolveOutputMode(tc.jsonl, tc.text, tc.json)
 			if tc.wantError {
 				if err == nil {
 					t.Fatal("expected mutual exclusion error")

--- a/internal/cli/pipeline/pipeline_test.go
+++ b/internal/cli/pipeline/pipeline_test.go
@@ -31,19 +31,19 @@ func TestEnvelopeValidate(t *testing.T) {
 	}
 }
 
-func TestDecodeJSONL(t *testing.T) {
-	envelope, err := DecodeJSONL(`{"schema":"javdb.pipeline/v1","kind":"movie","ref":"SSIS-589","id":"9DGB5X"}`)
+func TestDecodeNDJSON(t *testing.T) {
+	envelope, err := DecodeNDJSON(`{"schema":"javdb.pipeline/v1","kind":"movie","ref":"SSIS-589","id":"9DGB5X"}`)
 	if err != nil {
-		t.Fatalf("DecodeJSONL: %v", err)
+		t.Fatalf("DecodeNDJSON: %v", err)
 	}
 	if envelope.Ref != "SSIS-589" || envelope.ID != "9DGB5X" {
 		t.Errorf("envelope = %+v", envelope)
 	}
 
 	// meta/data 保留。
-	envelope, err = DecodeJSONL(`{"schema":"javdb.pipeline/v1","kind":"movie","ref":"x","meta":{"source":"builtin"}}`)
+	envelope, err = DecodeNDJSON(`{"schema":"javdb.pipeline/v1","kind":"movie","ref":"x","meta":{"source":"builtin"}}`)
 	if err != nil {
-		t.Fatalf("DecodeJSONL with meta: %v", err)
+		t.Fatalf("DecodeNDJSON with meta: %v", err)
 	}
 	if envelope.Meta["source"] != "builtin" {
 		t.Errorf("meta lost: %+v", envelope.Meta)
@@ -61,14 +61,14 @@ func TestDecodeJSONL(t *testing.T) {
 		{name: "no ref", line: `{"schema":"javdb.pipeline/v1","kind":"movie"}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := DecodeJSONL(tc.line); err == nil {
-				t.Fatal("DecodeJSONL accepted invalid line")
+			if _, err := DecodeNDJSON(tc.line); err == nil {
+				t.Fatal("DecodeNDJSON accepted invalid line")
 			}
 		})
 	}
 }
 
-func TestParseBatchTextAndJSONL(t *testing.T) {
+func TestParseBatchTextAndNDJSON(t *testing.T) {
 	text, err := ParseBatch([]byte("SSIS-589\nHZGD-246\n"), KindMovie)
 	if err != nil {
 		t.Fatalf("ParseBatch text: %v", err)
@@ -77,21 +77,21 @@ func TestParseBatchTextAndJSONL(t *testing.T) {
 		t.Errorf("text batch = %+v", text)
 	}
 
-	jsonl, err := ParseBatch([]byte("{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"movie\",\"ref\":\"a\"}\n{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"movie\",\"ref\":\"b\"}\n"), KindJSONLInput)
+	ndjson, err := ParseBatch([]byte("{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"movie\",\"ref\":\"a\"}\n{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"movie\",\"ref\":\"b\"}\n"), KindNDJSONInput)
 	if err != nil {
-		t.Fatalf("ParseBatch jsonl: %v", err)
+		t.Fatalf("ParseBatch ndjson: %v", err)
 	}
-	if len(jsonl) != 2 || jsonl[0].Ref != "a" || jsonl[1].Ref != "b" {
-		t.Errorf("jsonl batch = %+v", jsonl)
+	if len(ndjson) != 2 || ndjson[0].Ref != "a" || ndjson[1].Ref != "b" {
+		t.Errorf("ndjson batch = %+v", ndjson)
 	}
 
 	// 混合/非法行必须带行号报错。
-	if _, err := ParseBatch([]byte("{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"movie\",\"ref\":\"a\"}\ngarbage\n"), KindJSONLInput); err == nil || !strings.Contains(err.Error(), "line 2") {
+	if _, err := ParseBatch([]byte("{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"movie\",\"ref\":\"a\"}\ngarbage\n"), KindNDJSONInput); err == nil || !strings.Contains(err.Error(), "line 2") {
 		t.Fatalf("mixed batch error = %v", err)
 	}
 }
 
-func TestClassifyImageJSONLText(t *testing.T) {
+func TestClassifyImageNDJSONText(t *testing.T) {
 	// 图片 magic 优先。
 	classification, content, err := Classify(bufio.NewReader(bytes.NewReader(testJPEG)))
 	if err != nil || classification != ClassificationImage {
@@ -99,14 +99,14 @@ func TestClassifyImageJSONLText(t *testing.T) {
 	}
 	_ = content
 
-	// JSONL。
-	jsonl := []byte("{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"movie\",\"ref\":\"a\"}\n{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"movie\",\"ref\":\"b\"}\n")
-	classification, content, err = Classify(bufio.NewReader(bytes.NewReader(jsonl)))
-	if err != nil || classification != ClassificationJSONL {
-		t.Fatalf("jsonl classification = %v err=%v", classification, err)
+	// NDJSON。
+	ndjson := []byte("{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"movie\",\"ref\":\"a\"}\n{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"movie\",\"ref\":\"b\"}\n")
+	classification, content, err = Classify(bufio.NewReader(bytes.NewReader(ndjson)))
+	if err != nil || classification != ClassificationNDJSON {
+		t.Fatalf("ndjson classification = %v err=%v", classification, err)
 	}
-	if !bytes.Equal(content, jsonl) {
-		t.Error("jsonl content not preserved")
+	if !bytes.Equal(content, ndjson) {
+		t.Error("ndjson content not preserved")
 	}
 
 	// 文本。
@@ -125,21 +125,18 @@ func TestClassifyImageJSONLText(t *testing.T) {
 func TestResolveOutputMode(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
-		jsonl     bool
-		text      bool
+		ndjson    bool
 		json      bool
 		want      OutputMode
 		wantError bool
 	}{
 		{name: "default", want: OutputText},
-		{name: "explicit jsonl", jsonl: true, want: OutputJSONL},
-		{name: "explicit text", text: true, want: OutputText},
+		{name: "explicit ndjson", ndjson: true, want: OutputNDJSON},
 		{name: "explicit json", json: true, want: OutputJSON},
-		{name: "jsonl and json", jsonl: true, json: true, wantError: true},
-		{name: "all three", jsonl: true, text: true, json: true, wantError: true},
+		{name: "ndjson and json", ndjson: true, json: true, wantError: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			mode, err := ResolveOutputMode(tc.jsonl, tc.text, tc.json)
+			mode, err := ResolveOutputMode(tc.ndjson, tc.json)
 			if tc.wantError {
 				if err == nil {
 					t.Fatal("expected mutual exclusion error")
@@ -156,22 +153,22 @@ func TestResolveOutputMode(t *testing.T) {
 func TestWriterModes(t *testing.T) {
 	envelope := New(KindMovie, "SSIS-589", "9DGB5X")
 
-	// JSONL：每行一个信封。
-	var jsonlOut bytes.Buffer
-	jsonlWriter := NewWriter(&jsonlOut, OutputJSONL)
-	if err := jsonlWriter.Write(envelope); err != nil {
+	// NDJSON：每行一个信封。
+	var ndjsonOut bytes.Buffer
+	ndjsonWriter := NewWriter(&ndjsonOut, OutputNDJSON)
+	if err := ndjsonWriter.Write(envelope); err != nil {
 		t.Fatal(err)
 	}
-	if err := jsonlWriter.Write(envelope.WithData(map[string]any{"n": 1})); err != nil {
+	if err := ndjsonWriter.Write(envelope.WithData(map[string]any{"n": 1})); err != nil {
 		t.Fatal(err)
 	}
-	lines := strings.Split(strings.TrimSpace(jsonlOut.String()), "\n")
+	lines := strings.Split(strings.TrimSpace(ndjsonOut.String()), "\n")
 	if len(lines) != 2 {
-		t.Fatalf("jsonl lines = %d", len(lines))
+		t.Fatalf("ndjson lines = %d", len(lines))
 	}
 	var parsed Envelope
 	if err := json.Unmarshal([]byte(lines[0]), &parsed); err != nil || parsed.Schema != Schema {
-		t.Fatalf("jsonl line invalid: %v", err)
+		t.Fatalf("ndjson line invalid: %v", err)
 	}
 
 	// Text：逐行 ref。
@@ -217,7 +214,7 @@ func TestWriterModes(t *testing.T) {
 
 func TestRunBatchOrderErrorsAndExit(t *testing.T) {
 	var out bytes.Buffer
-	writer := NewWriter(&out, OutputJSONL)
+	writer := NewWriter(&out, OutputNDJSON)
 	inputs := []Envelope{
 		New(KindMovie, "a", ""),
 		New(KindMovie, "b", ""),
@@ -256,9 +253,9 @@ func (e testError) Error() string { return string(e) }
 // TestTagKindRoundTrip tags 自产的 tag 信封必须能通过管道解码。
 func TestTagKindRoundTrip(t *testing.T) {
 	line := `{"schema":"javdb.pipeline/v1","kind":"tag","ref":"VR","id":"t-1","data":{"name_zh":"VR"}}`
-	envelope, err := DecodeJSONL(line)
+	envelope, err := DecodeNDJSON(line)
 	if err != nil {
-		t.Fatalf("DecodeJSONL tag envelope: %v", err)
+		t.Fatalf("DecodeNDJSON tag envelope: %v", err)
 	}
 	if envelope.Kind != KindTag || envelope.ID != "t-1" {
 		t.Errorf("tag envelope = %+v", envelope)

--- a/internal/cli/pipeline/producer.go
+++ b/internal/cli/pipeline/producer.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ListProducer 是"拉取列表"类 producer 命令的通用执行器：
-// 不消费 stdin；非 TTY 输出逐条信封；TTY 人类文本；显式 --json 走 JSON 载荷。
+// 不消费 stdin；默认输出人类文本；显式 --jsonl 输出逐条信封，--json 走 JSON 载荷。
 type ListProducer struct {
 	Name string
 	// ClientFactory 每次执行调用一次。
@@ -33,7 +33,7 @@ type ListProducer struct {
 
 // Execute 是 producer 命令 RunE 的通用实现。
 func (p *ListProducer) Execute(streams *invocation.Streams, jsonl, text, json bool) error {
-	mode, err := ResolveOutputMode(jsonl, text, json, streams.InIsTerminal)
+	mode, err := ResolveOutputMode(jsonl, text, json)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/pipeline/producer.go
+++ b/internal/cli/pipeline/producer.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ListProducer 是"拉取列表"类 producer 命令的通用执行器：
-// 不消费 stdin；默认输出人类文本；显式 --jsonl 输出逐条信封，--json 走 JSON 载荷。
+// 不消费 stdin；默认输出人类文本；显式 --ndjson 输出逐条信封，--json 走 JSON 载荷。
 type ListProducer struct {
 	Name string
 	// ClientFactory 每次执行调用一次。
@@ -32,8 +32,8 @@ type ListProducer struct {
 }
 
 // Execute 是 producer 命令 RunE 的通用实现。
-func (p *ListProducer) Execute(streams *invocation.Streams, jsonl, text, json bool) error {
-	mode, err := ResolveOutputMode(jsonl, text, json)
+func (p *ListProducer) Execute(streams *invocation.Streams, ndjson, json bool) error {
+	mode, err := ResolveOutputMode(ndjson, json)
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func (p *ListProducer) Execute(streams *invocation.Streams, jsonl, text, json bo
 		if itemRef == nil {
 			itemRef = movieItemRef
 		}
-		writer := NewWriter(streams.Out, OutputJSONL)
+		writer := NewWriter(streams.Out, OutputNDJSON)
 		for _, item := range items {
 			ref, id := itemRef(item)
 			envelope := New(kind, ref, id).WithData(map[string]any{"item": item})

--- a/internal/cli/pipeline/runner.go
+++ b/internal/cli/pipeline/runner.go
@@ -36,7 +36,7 @@ type BatchRunner struct {
 
 // Execute 是命令 RunE 的通用实现。
 func (b *BatchRunner) Execute(streams *invocation.Streams, args []string, jsonl, text, json bool) error {
-	mode, err := ResolveOutputMode(jsonl, text, json, streams.InIsTerminal)
+	mode, err := ResolveOutputMode(jsonl, text, json)
 	if err != nil {
 		return err
 	}
@@ -94,8 +94,8 @@ func pipelineConsumerRef(input Envelope) string {
 	return input.Ref
 }
 
-// Producer 是无位置参数命令的非 TTY 输出器：不消费 stdin，非 TTY 时把结果
-// 逐条输出为信封；TTY 走 Text 渲染；显式 --json 走 LegacyJSON。
+// Producer 是无位置参数命令的输出器：不消费 stdin，默认走 Text 渲染；
+// 显式 --jsonl 逐条输出信封，--json 走 LegacyJSON。
 type Producer struct {
 	Name string
 	// Produce 执行并返回输出信封序列（空切片表示无结果）。
@@ -108,7 +108,7 @@ type Producer struct {
 
 // Execute 是 producer 命令 RunE 的通用实现。
 func (p *Producer) Execute(streams *invocation.Streams, jsonl, text, json bool) error {
-	mode, err := ResolveOutputMode(jsonl, text, json, streams.InIsTerminal)
+	mode, err := ResolveOutputMode(jsonl, text, json)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/pipeline/runner.go
+++ b/internal/cli/pipeline/runner.go
@@ -13,7 +13,7 @@ import (
 // BatchRunner 是只读命令的管道化执行器：
 //   - 单项 + （TTY 文本 或 显式 --json）走 Legacy 既有路径（保持既有 shape
 //     与可选认证/匿名重试行为）。
-//   - 其余情况（多项，或单项显式 --jsonl）走逐项 RunOne：单项失败原位错误
+//   - 其余情况（多项，或单项显式 --ndjson）走逐项 RunOne：单项失败原位错误
 //     信封并继续，最终非零；批量显式 --json 输出信封数组。
 type BatchRunner struct {
 	Name string
@@ -35,8 +35,8 @@ type BatchRunner struct {
 }
 
 // Execute 是命令 RunE 的通用实现。
-func (b *BatchRunner) Execute(streams *invocation.Streams, args []string, jsonl, text, json bool) error {
-	mode, err := ResolveOutputMode(jsonl, text, json)
+func (b *BatchRunner) Execute(streams *invocation.Streams, args []string, ndjson, json bool) error {
+	mode, err := ResolveOutputMode(ndjson, json)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func (b *BatchRunner) Execute(streams *invocation.Streams, args []string, jsonl,
 // ExecuteWithInputs 处理已收集的输入（调用方已完成分类）。
 func (b *BatchRunner) ExecuteWithInputs(streams *invocation.Streams, inputs []Envelope, mode OutputMode) error {
 	// 单项 TTY 文本或显式 --json（且 Legacy 支持 JSON）且输入是纯文本 ref
-	// （无 kind）时走既有路径，保持 shape 与认证语义；JSONL 信封即使只有一条
+	// （无 kind）时走既有路径，保持 shape 与认证语义；NDJSON 信封即使只有一条
 	// 也必须经过 kind 校验并保留 id 语义，绝不绕过消费者检查。Legacy 不支持
 	// JSON 的命令在显式 --json 下走 consumer 路径输出信封对象。
 	if len(inputs) == 1 && inputs[0].Kind == "" && (mode == OutputText || (mode == OutputJSON && b.LegacyJSON)) {
@@ -95,7 +95,7 @@ func pipelineConsumerRef(input Envelope) string {
 }
 
 // Producer 是无位置参数命令的输出器：不消费 stdin，默认走 Text 渲染；
-// 显式 --jsonl 逐条输出信封，--json 走 LegacyJSON。
+// 显式 --ndjson 逐条输出信封，--json 走 LegacyJSON。
 type Producer struct {
 	Name string
 	// Produce 执行并返回输出信封序列（空切片表示无结果）。
@@ -107,8 +107,8 @@ type Producer struct {
 }
 
 // Execute 是 producer 命令 RunE 的通用实现。
-func (p *Producer) Execute(streams *invocation.Streams, jsonl, text, json bool) error {
-	mode, err := ResolveOutputMode(jsonl, text, json)
+func (p *Producer) Execute(streams *invocation.Streams, ndjson, json bool) error {
+	mode, err := ResolveOutputMode(ndjson, json)
 	if err != nil {
 		return err
 	}
@@ -122,7 +122,7 @@ func (p *Producer) Execute(streams *invocation.Streams, jsonl, text, json bool) 
 	case OutputText:
 		return p.RenderText(streams.Out, envelopes)
 	default:
-		writer := NewWriter(streams.Out, OutputJSONL)
+		writer := NewWriter(streams.Out, OutputNDJSON)
 		for _, envelope := range envelopes {
 			if err := writer.Write(envelope); err != nil {
 				return err

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -139,7 +139,7 @@ Flags:
       --page int           Page number (default 1)
       --sort string        relevance|release|score|update|hit
       --source string      Reverse-search source (default: reverse_search.default_source)
-      --text               Plain text lines (default for TTY)
+      --text               Plain text lines (default)
       --type string        movie|code|series|actor|maker|director|list
       --zone string        censored|uncensored|western|fc2|all (default "censored")
 
@@ -158,7 +158,7 @@ Flags:
       --json      Machine-readable JSON
       --jsonl     Pipeline JSONL envelopes
       --magnets   Also list magnet links
-      --text      Plain text lines (default for TTY)
+      --text      Plain text lines (default)
 
 Global Flags:
       --host string    auto|mirror|main|URL (default: config or auto)
@@ -178,7 +178,7 @@ Flags:
       --json              Machine-readable JSON
       --jsonl             Pipeline JSONL envelopes
       --min-size string   Min size e.g. 2000, 4GB, 500MB
-      --text              Plain text lines (default for TTY)
+      --text              Plain text lines (default)
 
 Global Flags:
       --host string    auto|mirror|main|URL (default: config or auto)
@@ -196,7 +196,7 @@ Flags:
       --json             Machine-readable JSON
       --jsonl            Pipeline JSONL envelopes
       --score int        Optional score
-      --text             Plain text lines (default for TTY)
+      --text             Plain text lines (default)
       --want             Mark as 想看
       --watched          Mark as 看過
 
@@ -222,7 +222,7 @@ Flags:
       --limit int        Page size (default 20)
       --page int         Page (default 1)
       --sort-by string   created|name|movies_count|views_count|updated|default (default "created")
-      --text             Plain text lines (default for TTY)
+      --text             Plain text lines (default)
 
 Global Flags:
       --host string    auto|mirror|main|URL (default: config or auto)

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -133,13 +133,12 @@ Flags:
   -h, --help               help for search
       --image              Treat the argument as an image path or HTTP(S) URL
       --json               Machine-readable JSON
-      --jsonl              Pipeline JSONL envelopes
       --limit int          Page size (0 = server default)
+      --ndjson             Pipeline NDJSON envelopes
       --no-cache           Bypass the reverse-search response cache
       --page int           Page number (default 1)
       --sort string        relevance|release|score|update|hit
       --source string      Reverse-search source (default: reverse_search.default_source)
-      --text               Plain text lines (default)
       --type string        movie|code|series|actor|maker|director|list
       --zone string        censored|uncensored|western|fc2|all (default "censored")
 
@@ -156,9 +155,8 @@ Flags:
   -h, --help      help for detail
   -i, --id        Treat argument as internal movie id
       --json      Machine-readable JSON
-      --jsonl     Pipeline JSONL envelopes
       --magnets   Also list magnet links
-      --text      Plain text lines (default)
+      --ndjson    Pipeline NDJSON envelopes
 
 Global Flags:
       --host string    auto|mirror|main|URL (default: config or auto)
@@ -176,9 +174,8 @@ Flags:
   -h, --help              help for magnets
   -i, --id                Treat NUMBER as internal movie id
       --json              Machine-readable JSON
-      --jsonl             Pipeline JSONL envelopes
       --min-size string   Min size e.g. 2000, 4GB, 500MB
-      --text              Plain text lines (default)
+      --ndjson            Pipeline NDJSON envelopes
 
 Global Flags:
       --host string    auto|mirror|main|URL (default: config or auto)
@@ -194,9 +191,8 @@ Flags:
   -h, --help             help for mark
   -i, --id               Treat NUMBER as internal movie id
       --json             Machine-readable JSON
-      --jsonl            Pipeline JSONL envelopes
+      --ndjson           Pipeline NDJSON envelopes
       --score int        Optional score
-      --text             Plain text lines (default)
       --want             Mark as 想看
       --watched          Mark as 看過
 
@@ -218,11 +214,10 @@ Available Commands:
 Flags:
   -h, --help             help for lists
       --json             JSON output
-      --jsonl            Pipeline JSONL envelopes
       --limit int        Page size (default 20)
+      --ndjson           Pipeline NDJSON envelopes
       --page int         Page (default 1)
       --sort-by string   created|name|movies_count|views_count|updated|default (default "created")
-      --text             Plain text lines (default)
 
 Global Flags:
       --host string    auto|mirror|main|URL (default: config or auto)
@@ -412,12 +407,31 @@ func TestConfigSetPersistsHostValue(t *testing.T) {
 	}
 	out.Reset()
 	errb.Reset()
-	code = Run([]string{"config", "get", "host", "--text"}, strings.NewReader(""), &out, &errb)
+	code = Run([]string{"config", "get", "host"}, strings.NewReader(""), &out, &errb)
 	if code != 0 {
 		t.Fatalf("config get exit=%d stderr=%q", code, errb.String())
 	}
 	if got := strings.TrimSpace(out.String()); got != "main" {
 		t.Fatalf("host after set = %q, want %q", got, "main")
+	}
+}
+
+// TestOutputFlagsExposeOnlyJSONAndNDJSON 锁定纯文本只作为隐式默认，逐行
+// JSON 使用 NDJSON 命名。
+func TestOutputFlagsExposeOnlyJSONAndNDJSON(t *testing.T) {
+	var out, errb bytes.Buffer
+	code := Run([]string{"search", "--help"}, strings.NewReader(""), &out, &errb)
+	if code != 0 {
+		t.Fatalf("search help exit=%d stderr=%q", code, errb.String())
+	}
+	if strings.Contains(out.String(), "--text") {
+		t.Fatalf("search help unexpectedly exposes --text:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "--jsonl") {
+		t.Fatalf("search help unexpectedly exposes --jsonl:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "--ndjson") {
+		t.Fatalf("search help lacks --ndjson:\n%s", out.String())
 	}
 }
 

--- a/skills/javdb-cli/SKILL.md
+++ b/skills/javdb-cli/SKILL.md
@@ -121,9 +121,9 @@ javdb unmark SSIS-589
    "无结果"。
 2. 反搜缓存：默认启用（30 天，按 source + 原图 SHA-256）。`javdb cache reverse-search
    [--source NAME] [--clear]` 只清理反搜缓存；`--no-cache` 按次绕过。
-3. 管道：多数命令接受非 TTY stdin 批处理并默认输出文本；显式 `--jsonl` 才输出
-   `javdb.pipeline/v1` JSONL 信封（`--jsonl`/`--text`/`--json` 互斥）。例如
-   `javdb search SSIS --jsonl | javdb detail`。位置参数与非空 stdin 同时出现是歧义错误。
+3. 管道：多数命令接受非 TTY stdin 批处理并默认输出文本；显式 `--ndjson` 才输出
+   `javdb.pipeline/v1` NDJSON 信封（`--ndjson`/`--json` 互斥）。例如
+   `javdb search SSIS --ndjson | javdb detail`。位置参数与非空 stdin 同时出现是歧义错误。
    `auth login`、`config set` 与密码提示不使用管道 stdin。
 
 ## 路由

--- a/skills/javdb-cli/SKILL.md
+++ b/skills/javdb-cli/SKILL.md
@@ -121,8 +121,8 @@ javdb unmark SSIS-589
    "无结果"。
 2. 反搜缓存：默认启用（30 天，按 source + 原图 SHA-256）。`javdb cache reverse-search
    [--source NAME] [--clear]` 只清理反搜缓存；`--no-cache` 按次绕过。
-3. 管道：多数命令接受非 TTY stdin 批处理并默认输出 `javdb.pipeline/v1` JSONL 信封
-   （`--jsonl`/`--text`/`--json` 互斥）。例如
+3. 管道：多数命令接受非 TTY stdin 批处理并默认输出文本；显式 `--jsonl` 才输出
+   `javdb.pipeline/v1` JSONL 信封（`--jsonl`/`--text`/`--json` 互斥）。例如
    `javdb search SSIS --jsonl | javdb detail`。位置参数与非空 stdin 同时出现是歧义错误。
    `auth login`、`config set` 与密码提示不使用管道 stdin。
 


### PR DESCRIPTION
## Summary / 概述

Fix piped CLI invocations selecting structured output merely because stdout is non-TTY. Pipeline input detection remains unchanged. Output now defaults to text, `--json` explicitly selects JSON, and `--ndjson` explicitly selects newline-delimited pipeline envelopes. The redundant `--text` flag and the former `--jsonl` spelling are removed.

## Scope and compatibility / 范围与兼容性

- Affects all CLI commands using the shared pipeline output resolver.
- Default piped output changes from implicit structured output to text.
- Replace `--jsonl` with `--ndjson`; remove `--text`. Scripts requiring pipeline envelopes must pass `--ndjson`.
- Rename related internal JSONL identifiers, classifiers, parsers, output modes, variables, comments, and tests to NDJSON.
- Updates both CLI references, both READMEs, maintainer architecture, operator skill, e2e coverage, help snapshots, and focused tests.
- Public Go SDK, configuration, authentication, and release workflows are unchanged.

## Verification / 验证

```text
go test ./...                                              # passed
sh scripts/build.sh                                        # passed
rg --files -g "*.go" -0 | xargs -0 gopls check           # passed, no diagnostics
bash -n e2e/run.sh                                         # passed
printf "<number>\n" | ./build/javdb search             # passed; plain text
printf "<number>\n" | ./build/javdb search --json | jq ...   # passed
printf "<number>\n<number>\n" | ./build/javdb search --ndjson | jq ... # passed
./build/javdb search <number> --text                       # rejected as unknown flag
./build/javdb search <number> --jsonl                      # rejected as unknown flag
```

Real JavDB App API e2e was run with public movie identifiers. Only pass/fail and redacted command evidence is included.

## Release note declaration / Release note 声明

<!-- release-note
category: Fixed
breaking: true
summary: Piped commands now default to text; use --json for JSON or --ndjson for newline-delimited pipeline envelopes.
none_reason:
-->

## Checklist / 检查清单

- [x] The change is focused and linked to an issue when appropriate. / 改动目标明确，并在适用时关联 Issue。
- [x] I added or updated focused tests for changed behavior. / 我已为变更行为新增或更新聚焦测试。
- [x] I ran the relevant tests and recorded the results above. / 我已运行相关测试并在上方记录结果。
- [x] I updated the required CLI reference, SDK, README, maintainer, and operator-skill documentation. / 我已更新所需的 CLI reference、SDK、README、维护者和 operator-skill 文档。
- [x] I completed the required release-note declaration above; `None` has a concrete reason when selected. / 我已填写上方必需的 release-note 声明；选择 `None` 时已提供具体理由。
- [x] I documented every new timeout, retry, pagination or result limit, truncation, fallback, or downgrade and its evidence. / 我已记录每项新增 timeout、retry、pagination 或结果限制、truncation、fallback 或 downgrade 及其证据。
- [x] I did not add passwords, JWTs, `~/.javdb-cli/auth.json` contents, proxy credentials, private URLs, local state, or private API responses. / 我没有添加密码、JWT、`~/.javdb-cli/auth.json` 内容、代理凭据、私有 URL、本地状态或私有 API 响应。
- [x] I updated migration guidance for every breaking change. / 我已为每个破坏性变更更新迁移指引。