### PR TITLE
fix(release): align ClawHub skill with v0.7.1

### DIFF
--- a/skills/javdb-cli/SKILL.md
+++ b/skills/javdb-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 slug: javdb-cli
-version: 0.5.2
+version: 0.7.1
 displayName: JavDB CLI
 summary: Safely operate JavDB through the javdb-cli binary for discovery, authenticated lists, and explicit state changes.
 license: MIT


### PR DESCRIPTION
## Summary / 概述

Prepare the javdb-cli operator skill for the next v0.7.1 release by aligning its metadata version with the immutable release tag that will publish it to ClawHub.

This supersedes the closed #25 approach. Because v0.7.1 has not been released yet, it uses the existing normal tag-based publication path and does not add a default-branch backfill bypass.

## Scope and compatibility / 范围与兼容性

- Operator skill: `skills/javdb-cli/SKILL.md` version changes from `0.5.2` to `0.7.1`.
- ClawHub publication: a future immutable `v0.7.1` tag will satisfy the existing skill-version consistency check and publish through the normal Release handoff.
- CLI commands, flags, public Go SDK, configuration, authentication, workflows, binary assets, and changelog: None.
- Compatibility: no breaking changes. This PR does not create a tag, publish a Release, invoke ClawHub, or merge itself.

## Verification / 验证

```text
test "$(sed -n "s/^version: //p" skills/javdb-cli/SKILL.md)" = 0.7.1
test "$(grep -c "^version: " skills/javdb-cli/SKILL.md)" = 1
sh scripts/test-clawhub-publish-workflow.sh
sh scripts/test-workflows.sh
sh scripts/test-documentation.sh
sh scripts/test-releasenotes.sh
go test ./...
git diff --check
```

All commands passed. Real JavDB App API coverage was not run because this change only updates release skill metadata.

## Release note declaration / Release note 声明

<!-- release-note
category: Fixed
breaking: false
summary: Align the ClawHub operator skill metadata with the upcoming v0.7.1 release.
none_reason:
-->

## Checklist / 检查清单

- [x] The change is focused and linked to an issue when appropriate. / 改动目标明确，并在适用时关联 Issue。
- [x] I added or updated focused tests for changed behavior. / 我已为变更行为新增或更新聚焦测试。
- [x] I ran the relevant tests and recorded the results above. / 我已运行相关测试并在上方记录结果。
- [x] I updated the required CLI reference, SDK, README, maintainer, and operator-skill documentation. / 我已更新所需的 CLI reference、SDK、README、维护者和 operator-skill 文档。
- [x] I completed the required release-note declaration above; `None` has a concrete reason when selected. / 我已填写上方必需的 release-note 声明；选择 `None` 时已提供具体理由。
- [x] I documented every new timeout, retry, pagination or result limit, truncation, fallback, or downgrade and its evidence. / 我已记录每项新增 timeout、retry、pagination 或结果限制、truncation、fallback 或 downgrade 及其证据。
- [x] I did not add passwords, JWTs, `~/.javdb-cli/auth.json` contents, proxy credentials, private URLs, local state, or private API responses. / 我没有添加密码、JWT、`~/.javdb-cli/auth.json` 内容、代理凭据、私有 URL、本地状态或私有 API 响应。
- [x] I updated migration guidance for every breaking change. / 我已为每个破坏性变更更新迁移指引。

## Summary by Sourcery

Bug Fixes:
- 确保 `javdb-cli` operator skill 的版本与即将发布的 `v0.7.1` 标签一致，以满足 ClawHub 发布检查的要求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure the javdb-cli operator skill version matches the upcoming v0.7.1 release tag to satisfy ClawHub publication checks.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 将 `javdb-cli` 技能版本更新至 0.7.1。
  * 其他元数据和操作说明保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->