### PR TITLE
docs(release): prepare v0.7.1

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@ grouped by user outcome and carry inline PR or historical direct-commit sources;
 | Version | Date | Release notes |
 | --- | --- | --- |
 | Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
+| [v0.7.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.0...v0.7.1) | 2026-08-14 | [English](v0.7.1/en.md) · [简体中文](v0.7.1/zh-CN.md) |
 | [v0.7.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.6.1...v0.7.0) | 2026-08-14 | [English](v0.7.0/en.md) · [简体中文](v0.7.0/zh-CN.md) |
 | [v0.6.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.6.0...v0.6.1) | 2026-08-13 | [English](v0.6.1/en.md) · [简体中文](v0.6.1/zh-CN.md) |
 | [v0.6.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.5.2...v0.6.0) | 2026-08-12 | [English](v0.6.0/en.md) · [简体中文](v0.6.0/zh-CN.md) |

--- a/changelog/README.zh-CN.md
+++ b/changelog/README.zh-CN.md
@@ -5,6 +5,7 @@
 | 版本 | 日期 | 发布说明 |
 | --- | --- | --- |
 | Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
+| [v0.7.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.0...v0.7.1) | 2026-08-14 | [English](v0.7.1/en.md) · [简体中文](v0.7.1/zh-CN.md) |
 | [v0.7.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.6.1...v0.7.0) | 2026-08-14 | [English](v0.7.0/en.md) · [简体中文](v0.7.0/zh-CN.md) |
 | [v0.6.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.6.0...v0.6.1) | 2026-08-13 | [English](v0.6.1/en.md) · [简体中文](v0.6.1/zh-CN.md) |
 | [v0.6.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.5.2...v0.6.0) | 2026-08-12 | [English](v0.6.0/en.md) · [简体中文](v0.6.0/zh-CN.md) |

--- a/changelog/plans/v0.7.1.json
+++ b/changelog/plans/v0.7.1.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.7.1",
+  "previous_tag": "v0.7.0",
+  "compare_url": "https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.0...v0.7.1",
+  "entries": [
+    {
+      "category": "Fixed",
+      "breaking": true,
+      "english": "Make human-readable text the default output for piped commands, remove the redundant `--text` and former `--jsonl` flags, and expose explicit `--json` and `--ndjson` modes.",
+      "zh_cn": "管道命令默认输出人类可读文本，移除冗余的 `--text` 与原 `--jsonl` 参数，并提供显式的 `--json` 和 `--ndjson` 输出模式。",
+      "sources": [
+        "https://github.com/FlanChanXwO/javdb-cli/pull/26"
+      ]
+    },
+    {
+      "category": "Fixed",
+      "breaking": false,
+      "english": "Align the operator skill metadata with v0.7.1 so the immutable tagged Release publishes the exact skill to ClawHub through the normal handoff.",
+      "zh_cn": "将 operator skill 元数据同步到 v0.7.1，使不可变 tag 对应的 Release 通过正常交接链路向 ClawHub 发布精确版本。",
+      "sources": [
+        "https://github.com/FlanChanXwO/javdb-cli/pull/27"
+      ]
+    }
+  ],
+  "new_contributors": []
+}

--- a/changelog/v0.7.1/en.md
+++ b/changelog/v0.7.1/en.md
@@ -1,0 +1,11 @@
+# v0.7.1 — 2026-08-14
+
+## Breaking changes
+
+- Make human-readable text the default output for piped commands, remove the redundant `--text` and former `--jsonl` flags, and expose explicit `--json` and `--ndjson` modes. ([#26](https://github.com/FlanChanXwO/javdb-cli/pull/26))
+
+## Fixed
+
+- Align the operator skill metadata with v0.7.1 so the immutable tagged Release publishes the exact skill to ClawHub through the normal handoff. ([#27](https://github.com/FlanChanXwO/javdb-cli/pull/27))
+
+**Full Changelog**: [v0.7.0...v0.7.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.0...v0.7.1)

--- a/changelog/v0.7.1/zh-CN.md
+++ b/changelog/v0.7.1/zh-CN.md
@@ -1,0 +1,11 @@
+# v0.7.1 — 2026-08-14
+
+## 破坏性变更
+
+- 管道命令默认输出人类可读文本，移除冗余的 `--text` 与原 `--jsonl` 参数，并提供显式的 `--json` 和 `--ndjson` 输出模式。 ([#26](https://github.com/FlanChanXwO/javdb-cli/pull/26))
+
+## 修复
+
+- 将 operator skill 元数据同步到 v0.7.1，使不可变 tag 对应的 Release 通过正常交接链路向 ClawHub 发布精确版本。 ([#27](https://github.com/FlanChanXwO/javdb-cli/pull/27))
+
+**完整变更**：[v0.7.0...v0.7.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.0...v0.7.1)


### PR DESCRIPTION
## Summary / 概述

Prepare the audited bilingual v0.7.1 release notes and changelog indexes. Every release entry points to its source PR: #26 and #27.

准备经审计的 v0.7.1 中英双语发布说明与 changelog 索引。每项变更均指向来源 PR：#26、#27。

## Scope and compatibility / 范围与兼容性

This PR changes release documentation only. The release it describes includes the breaking CLI output/flag change from #26: piped commands default to text, explicit structured modes are `--json` and `--ndjson`, and `--text`/`--jsonl` are removed. The requested release target is v0.7.1.

本 PR 仅修改发布文档。其描述的版本包含 #26 的破坏性 CLI 输出/参数变更：管道命令默认输出文本，结构化输出显式使用 `--json` 或 `--ndjson`，并移除 `--text`/`--jsonl`。目标版本按要求为 v0.7.1。

## Verification / 验证

All commands passed / 以下命令均通过：

```text
jq empty changelog/plans/v0.7.1.json
go run ./scripts/releasenotes prepare --version 0.7.1 --previous v0.7.0 --date 2026-08-14 --plan changelog/plans/v0.7.1.json --audit /tmp/javdb-v0.7.1-audit.json
go run ./scripts/releasenotes validate --version 0.7.1 --previous v0.7.0 --dir changelog/v0.7.1 --audit /tmp/javdb-v0.7.1-audit.json
go test ./...
go test -race ./...
go vet ./...
sh scripts/build.sh
sh scripts/test-releasenotes.sh
sh scripts/test-package-release.sh
sh scripts/test-homebrew-formula.sh
sh scripts/test-workflows.sh
sh scripts/test-clawhub-publish-workflow.sh
sh scripts/test-documentation.sh
sh scripts/test-architecture.sh
git diff --check
pre-commit run --all-files
```

Real JavDB App API coverage was not run because this PR changes release documentation only.

未运行真实 JavDB App API 验证，因为本 PR 仅修改发布文档。

## Release note declaration / Release note 声明

<!-- release-note
category: None
breaking: false
summary: Prepare the audited bilingual v0.7.1 release notes.
none_reason: This is the release-prep PR; user-visible changes are already represented by the versioned entries sourced from PR #26 and PR #27.
-->

## Checklist / 检查清单

- [x] The change is focused and linked to an issue when appropriate. / 改动目标明确，并在适用时关联 Issue。
- [x] I added or updated focused tests for changed behavior. / 我已为变更行为新增或更新聚焦测试。
- [x] I ran the relevant tests and recorded the results above. / 我已运行相关测试并在上方记录结果。
- [x] I updated the required CLI reference, SDK, README, maintainer, and operator-skill documentation. / 我已更新所需的 CLI reference、SDK、README、维护者和 operator-skill 文档。
- [x] I completed the required release-note declaration above; `None` has a concrete reason when selected. / 我已填写上方必需的 release-note 声明；选择 `None` 时已提供具体理由。
- [x] I documented every new timeout, retry, pagination or result limit, truncation, fallback, or downgrade and its evidence. / 我已记录每项新增 timeout、retry、pagination 或结果限制、truncation、fallback 或 downgrade 及其证据。
- [x] I did not add passwords, JWTs, `~/.javdb-cli/auth.json` contents, proxy credentials, private URLs, local state, or private API responses. / 我没有添加密码、JWT、`~/.javdb-cli/auth.json` 内容、代理凭据、私有 URL、本地状态或私有 API 响应。
- [x] I updated migration guidance for every breaking change. / 我已为每个破坏性变更更新迁移指引。

## Summary by Sourcery

为 v0.7.1 版本编写文档，包含带索引的双语更新日志条目及相关元数据。

文档：
- 添加 v0.7.1 版本的英文和简体中文发行说明，其中包括 CLI 输出标志变更以及操作员技能元数据修复。
- 更新更新日志索引 README 文件以引用新的 v0.7.1 发行说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document the v0.7.1 release with indexed, bilingual changelog entries and associated metadata.

Documentation:
- Add English and Simplified Chinese release notes for v0.7.1, including the CLI output flag changes and operator skill metadata fix.
- Update changelog index READMEs to reference the new v0.7.1 release notes.

</details>