### PR TITLE
docs(release): prepare v0.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ terms and the laws that apply to you.
   watch/want data, and reverse image search with strict number linking
   (`javdb search IMAGE`, `javdb cache reverse-search`).
 - **Composable pipelines** — most commands accept non-TTY stdin batches;
+  TTY stdout defaults to human-readable text, non-TTY to stable record streams;
   explicit `--ndjson` emits `javdb.pipeline/v1` envelopes so command output can
   feed the next command (`javdb search --ndjson | javdb detail`).
 - **API client, not a scraper** — commands use the App JSON API with explicit

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,7 +23,8 @@
 - **CLI 与公开 Go SDK**——CLI 与可导入的 `javdb` 包都覆盖搜索、详情、标签、浏览、实体片单、磁力、
   单页评论、选定缩略图/预览媒体下载、排行、TOP250、合集、已认证的想看/看过数据，以及以图搜番
   与严格番号联动（`javdb search IMAGE`、`javdb cache reverse-search`）。
-- **可组合管道**——多数命令接受非 TTY stdin 批处理；显式 `--ndjson` 输出
+- **可组合管道**——多数命令接受非 TTY stdin 批处理；TTY stdout 默认输出人类文本，
+  非 TTY stdout 默认输出稳定记录流；显式 `--ndjson` 输出
   `javdb.pipeline/v1` NDJSON 信封，可把上一条命令的结果直接喂给下一条
   （`javdb search --ndjson | javdb detail`）。
 - **API 客户端而非爬虫**——命令通过 App JSON API 请求，并显式选择主机与代理；失败会原样

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@ grouped by user outcome and carry inline PR or historical direct-commit sources;
 | Version | Date | Release notes |
 | --- | --- | --- |
 | Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
+| [v0.7.2](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.1...v0.7.2) | 2026-08-16 | [English](v0.7.2/en.md) · [简体中文](v0.7.2/zh-CN.md) |
 | [v0.7.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.0...v0.7.1) | 2026-08-14 | [English](v0.7.1/en.md) · [简体中文](v0.7.1/zh-CN.md) |
 | [v0.7.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.6.1...v0.7.0) | 2026-08-14 | [English](v0.7.0/en.md) · [简体中文](v0.7.0/zh-CN.md) |
 | [v0.6.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.6.0...v0.6.1) | 2026-08-13 | [English](v0.6.1/en.md) · [简体中文](v0.6.1/zh-CN.md) |

--- a/changelog/README.zh-CN.md
+++ b/changelog/README.zh-CN.md
@@ -5,6 +5,7 @@
 | 版本 | 日期 | 发布说明 |
 | --- | --- | --- |
 | Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
+| [v0.7.2](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.1...v0.7.2) | 2026-08-16 | [English](v0.7.2/en.md) · [简体中文](v0.7.2/zh-CN.md) |
 | [v0.7.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.0...v0.7.1) | 2026-08-14 | [English](v0.7.1/en.md) · [简体中文](v0.7.1/zh-CN.md) |
 | [v0.7.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.6.1...v0.7.0) | 2026-08-14 | [English](v0.7.0/en.md) · [简体中文](v0.7.0/zh-CN.md) |
 | [v0.6.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.6.0...v0.6.1) | 2026-08-13 | [English](v0.6.1/en.md) · [简体中文](v0.6.1/zh-CN.md) |

--- a/changelog/plans/v0.7.2.json
+++ b/changelog/plans/v0.7.2.json
@@ -1,0 +1,52 @@
+{
+  "version": "0.7.2",
+  "previous_tag": "v0.7.1",
+  "compare_url": "https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.1...v0.7.2",
+  "entries": [
+    {
+      "category": "Added",
+      "breaking": false,
+      "english": "Add `search --magnets N`, stable magnet ranking and filtering, reverse-image magnet lookup, and fan-out pipeline records for movies and named entities.",
+      "zh_cn": "新增 `search --magnets N`、稳定的磁力排序与筛选、以图搜磁力，以及影片和命名实体的逐项管道记录输出。",
+      "sources": [
+        "https://github.com/FlanChanXwO/javdb-cli/commit/1054964661f213da0ff392ce680ec6d98cf58028",
+        "https://github.com/FlanChanXwO/javdb-cli/commit/32d8c3c46719c1e900cfb1d22198610cf2d35bdb",
+        "https://github.com/FlanChanXwO/javdb-cli/commit/b8a9ee5e5655c091095fed4ad49988648e533242",
+        "https://github.com/FlanChanXwO/javdb-cli/commit/ce932429c98d27cb7dfcb8c345a8fa1a1f0203ca",
+        "https://github.com/FlanChanXwO/javdb-cli/commit/d7c3f93c0400843637cf3383eccfb8e347305db5",
+        "https://github.com/FlanChanXwO/javdb-cli/commit/cd723be0a8e7f0da4832dea5222aa4ca5f34a2ea"
+      ]
+    },
+    {
+      "category": "Fixed",
+      "breaking": false,
+      "english": "Make non-TTY producer output consumable as stable refs, preserve upstream error envelopes, avoid redundant movie detail requests, and report partial magnet and output failures correctly.",
+      "zh_cn": "修复非 TTY producer 输出不可稳定消费、上游错误信封被重复处理、重复影片详情请求，以及部分磁力和输出失败未正确报告的问题。",
+      "sources": [
+        "https://github.com/FlanChanXwO/javdb-cli/commit/0fb52c613d412ac71126419dcbf82fcbea450b14",
+        "https://github.com/FlanChanXwO/javdb-cli/commit/23ec4e4e39cc1ae46d238f3949225612b5918909",
+        "https://github.com/FlanChanXwO/javdb-cli/commit/2ab4a7568344f0e1216b71499976a8b9c577c6a5",
+        "https://github.com/FlanChanXwO/javdb-cli/commit/2f9b0e91aa8169b4c3881bfd85aacfab23a159f5",
+        "https://github.com/FlanChanXwO/javdb-cli/commit/472e787d49db7925be0987b26a8f967bd76cae85",
+        "https://github.com/FlanChanXwO/javdb-cli/commit/79ab9dd385872d2ba665ec76ac2f79dd7bac45cb",
+        "https://github.com/FlanChanXwO/javdb-cli/commit/af0e83428c4db92a82bc6d2bd055d294934f2e34",
+        "https://github.com/FlanChanXwO/javdb-cli/commit/aff20fb6863d2ef71d02a8672bf3d57dbbdf2f53",
+        "https://github.com/FlanChanXwO/javdb-cli/commit/f6cae5be5a9d9d42553a166442d92f5e5c641060"
+      ]
+    },
+    {
+      "category": "Documentation",
+      "breaking": false,
+      "english": "Document the TTY-aware output contract and add focused acceptance coverage for the default text pipeline and producer projections.",
+      "zh_cn": "补充 TTY 感知的输出契约，并为默认文本管道和 producer 投影增加聚焦验收覆盖。",
+      "sources": [
+        "https://github.com/FlanChanXwO/javdb-cli/commit/53d42949f3f39177b22ac1d9c802ce5651ec7b27",
+        "https://github.com/FlanChanXwO/javdb-cli/commit/728f3695621ecd310e0dc43a815cf171c8b9b1bb",
+        "https://github.com/FlanChanXwO/javdb-cli/commit/180e55a645969a473de5e794099c57e67c63dfee",
+        "https://github.com/FlanChanXwO/javdb-cli/commit/cfa62f6d86fa81fe269be0bb257d41a4cc00cbf4",
+        "https://github.com/FlanChanXwO/javdb-cli/commit/98ecb82c5fa727067c8b9b3abb1bec72dc78bce3"
+      ]
+    }
+  ],
+  "new_contributors": []
+}

--- a/changelog/plans/v0.7.2.json
+++ b/changelog/plans/v0.7.2.json
@@ -9,42 +9,16 @@
       "english": "Add `search --magnets N`, stable magnet ranking and filtering, reverse-image magnet lookup, and fan-out pipeline records for movies and named entities.",
       "zh_cn": "新增 `search --magnets N`、稳定的磁力排序与筛选、以图搜磁力，以及影片和命名实体的逐项管道记录输出。",
       "sources": [
-        "https://github.com/FlanChanXwO/javdb-cli/commit/1054964661f213da0ff392ce680ec6d98cf58028",
-        "https://github.com/FlanChanXwO/javdb-cli/commit/32d8c3c46719c1e900cfb1d22198610cf2d35bdb",
-        "https://github.com/FlanChanXwO/javdb-cli/commit/b8a9ee5e5655c091095fed4ad49988648e533242",
-        "https://github.com/FlanChanXwO/javdb-cli/commit/ce932429c98d27cb7dfcb8c345a8fa1a1f0203ca",
-        "https://github.com/FlanChanXwO/javdb-cli/commit/d7c3f93c0400843637cf3383eccfb8e347305db5",
-        "https://github.com/FlanChanXwO/javdb-cli/commit/cd723be0a8e7f0da4832dea5222aa4ca5f34a2ea"
+        "https://github.com/FlanChanXwO/javdb-cli/pull/29"
       ]
     },
     {
       "category": "Fixed",
       "breaking": false,
-      "english": "Make non-TTY producer output consumable as stable refs, preserve upstream error envelopes, avoid redundant movie detail requests, and report partial magnet and output failures correctly.",
-      "zh_cn": "修复非 TTY producer 输出不可稳定消费、上游错误信封被重复处理、重复影片详情请求，以及部分磁力和输出失败未正确报告的问题。",
+      "english": "Make non-TTY producer output consumable as stable refs, preserve upstream error envelopes, avoid redundant movie detail requests, report partial magnet and output failures correctly, and align real API smoke checks with the output contract.",
+      "zh_cn": "修复非 TTY producer 输出不可稳定消费、上游错误信封被重复处理、重复影片详情请求，以及部分磁力和输出失败未正确报告的问题，并让真实 API 冒烟检查与输出契约一致。",
       "sources": [
-        "https://github.com/FlanChanXwO/javdb-cli/commit/0fb52c613d412ac71126419dcbf82fcbea450b14",
-        "https://github.com/FlanChanXwO/javdb-cli/commit/23ec4e4e39cc1ae46d238f3949225612b5918909",
-        "https://github.com/FlanChanXwO/javdb-cli/commit/2ab4a7568344f0e1216b71499976a8b9c577c6a5",
-        "https://github.com/FlanChanXwO/javdb-cli/commit/2f9b0e91aa8169b4c3881bfd85aacfab23a159f5",
-        "https://github.com/FlanChanXwO/javdb-cli/commit/472e787d49db7925be0987b26a8f967bd76cae85",
-        "https://github.com/FlanChanXwO/javdb-cli/commit/79ab9dd385872d2ba665ec76ac2f79dd7bac45cb",
-        "https://github.com/FlanChanXwO/javdb-cli/commit/af0e83428c4db92a82bc6d2bd055d294934f2e34",
-        "https://github.com/FlanChanXwO/javdb-cli/commit/aff20fb6863d2ef71d02a8672bf3d57dbbdf2f53",
-        "https://github.com/FlanChanXwO/javdb-cli/commit/f6cae5be5a9d9d42553a166442d92f5e5c641060"
-      ]
-    },
-    {
-      "category": "Documentation",
-      "breaking": false,
-      "english": "Document the TTY-aware output contract and add focused acceptance coverage for the default text pipeline and producer projections.",
-      "zh_cn": "补充 TTY 感知的输出契约，并为默认文本管道和 producer 投影增加聚焦验收覆盖。",
-      "sources": [
-        "https://github.com/FlanChanXwO/javdb-cli/commit/53d42949f3f39177b22ac1d9c802ce5651ec7b27",
-        "https://github.com/FlanChanXwO/javdb-cli/commit/728f3695621ecd310e0dc43a815cf171c8b9b1bb",
-        "https://github.com/FlanChanXwO/javdb-cli/commit/180e55a645969a473de5e794099c57e67c63dfee",
-        "https://github.com/FlanChanXwO/javdb-cli/commit/cfa62f6d86fa81fe269be0bb257d41a4cc00cbf4",
-        "https://github.com/FlanChanXwO/javdb-cli/commit/98ecb82c5fa727067c8b9b3abb1bec72dc78bce3"
+        "https://github.com/FlanChanXwO/javdb-cli/pull/29"
       ]
     }
   ],

--- a/changelog/v0.7.2/en.md
+++ b/changelog/v0.7.2/en.md
@@ -2,14 +2,10 @@
 
 ## Added
 
-- Add `search --magnets N`, stable magnet ranking and filtering, reverse-image magnet lookup, and fan-out pipeline records for movies and named entities. ([`1054964`](https://github.com/FlanChanXwO/javdb-cli/commit/1054964661f213da0ff392ce680ec6d98cf58028), [`32d8c3c`](https://github.com/FlanChanXwO/javdb-cli/commit/32d8c3c46719c1e900cfb1d22198610cf2d35bdb), [`b8a9ee5`](https://github.com/FlanChanXwO/javdb-cli/commit/b8a9ee5e5655c091095fed4ad49988648e533242), [`ce93242`](https://github.com/FlanChanXwO/javdb-cli/commit/ce932429c98d27cb7dfcb8c345a8fa1a1f0203ca), [`d7c3f93`](https://github.com/FlanChanXwO/javdb-cli/commit/d7c3f93c0400843637cf3383eccfb8e347305db5), [`cd723be`](https://github.com/FlanChanXwO/javdb-cli/commit/cd723be0a8e7f0da4832dea5222aa4ca5f34a2ea))
+- Add `search --magnets N`, stable magnet ranking and filtering, reverse-image magnet lookup, and fan-out pipeline records for movies and named entities. ([#29](https://github.com/FlanChanXwO/javdb-cli/pull/29))
 
 ## Fixed
 
-- Make non-TTY producer output consumable as stable refs, preserve upstream error envelopes, avoid redundant movie detail requests, and report partial magnet and output failures correctly. ([`0fb52c6`](https://github.com/FlanChanXwO/javdb-cli/commit/0fb52c613d412ac71126419dcbf82fcbea450b14), [`23ec4e4`](https://github.com/FlanChanXwO/javdb-cli/commit/23ec4e4e39cc1ae46d238f3949225612b5918909), [`2ab4a75`](https://github.com/FlanChanXwO/javdb-cli/commit/2ab4a7568344f0e1216b71499976a8b9c577c6a5), [`2f9b0e9`](https://github.com/FlanChanXwO/javdb-cli/commit/2f9b0e91aa8169b4c3881bfd85aacfab23a159f5), [`472e787`](https://github.com/FlanChanXwO/javdb-cli/commit/472e787d49db7925be0987b26a8f967bd76cae85), [`79ab9dd`](https://github.com/FlanChanXwO/javdb-cli/commit/79ab9dd385872d2ba665ec76ac2f79dd7bac45cb), [`af0e834`](https://github.com/FlanChanXwO/javdb-cli/commit/af0e83428c4db92a82bc6d2bd055d294934f2e34), [`aff20fb`](https://github.com/FlanChanXwO/javdb-cli/commit/aff20fb6863d2ef71d02a8672bf3d57dbbdf2f53), [`f6cae5b`](https://github.com/FlanChanXwO/javdb-cli/commit/f6cae5be5a9d9d42553a166442d92f5e5c641060))
-
-## Documentation
-
-- Document the TTY-aware output contract and add focused acceptance coverage for the default text pipeline and producer projections. ([`53d4294`](https://github.com/FlanChanXwO/javdb-cli/commit/53d42949f3f39177b22ac1d9c802ce5651ec7b27), [`728f369`](https://github.com/FlanChanXwO/javdb-cli/commit/728f3695621ecd310e0dc43a815cf171c8b9b1bb), [`180e55a`](https://github.com/FlanChanXwO/javdb-cli/commit/180e55a645969a473de5e794099c57e67c63dfee), [`cfa62f6`](https://github.com/FlanChanXwO/javdb-cli/commit/cfa62f6d86fa81fe269be0bb257d41a4cc00cbf4), [`98ecb82`](https://github.com/FlanChanXwO/javdb-cli/commit/98ecb82c5fa727067c8b9b3abb1bec72dc78bce3))
+- Make non-TTY producer output consumable as stable refs, preserve upstream error envelopes, avoid redundant movie detail requests, report partial magnet and output failures correctly, and align real API smoke checks with the output contract. ([#29](https://github.com/FlanChanXwO/javdb-cli/pull/29))
 
 **Full Changelog**: [v0.7.1...v0.7.2](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.1...v0.7.2)

--- a/changelog/v0.7.2/en.md
+++ b/changelog/v0.7.2/en.md
@@ -1,0 +1,15 @@
+# v0.7.2 — 2026-08-16
+
+## Added
+
+- Add `search --magnets N`, stable magnet ranking and filtering, reverse-image magnet lookup, and fan-out pipeline records for movies and named entities. ([`1054964`](https://github.com/FlanChanXwO/javdb-cli/commit/1054964661f213da0ff392ce680ec6d98cf58028), [`32d8c3c`](https://github.com/FlanChanXwO/javdb-cli/commit/32d8c3c46719c1e900cfb1d22198610cf2d35bdb), [`b8a9ee5`](https://github.com/FlanChanXwO/javdb-cli/commit/b8a9ee5e5655c091095fed4ad49988648e533242), [`ce93242`](https://github.com/FlanChanXwO/javdb-cli/commit/ce932429c98d27cb7dfcb8c345a8fa1a1f0203ca), [`d7c3f93`](https://github.com/FlanChanXwO/javdb-cli/commit/d7c3f93c0400843637cf3383eccfb8e347305db5), [`cd723be`](https://github.com/FlanChanXwO/javdb-cli/commit/cd723be0a8e7f0da4832dea5222aa4ca5f34a2ea))
+
+## Fixed
+
+- Make non-TTY producer output consumable as stable refs, preserve upstream error envelopes, avoid redundant movie detail requests, and report partial magnet and output failures correctly. ([`0fb52c6`](https://github.com/FlanChanXwO/javdb-cli/commit/0fb52c613d412ac71126419dcbf82fcbea450b14), [`23ec4e4`](https://github.com/FlanChanXwO/javdb-cli/commit/23ec4e4e39cc1ae46d238f3949225612b5918909), [`2ab4a75`](https://github.com/FlanChanXwO/javdb-cli/commit/2ab4a7568344f0e1216b71499976a8b9c577c6a5), [`2f9b0e9`](https://github.com/FlanChanXwO/javdb-cli/commit/2f9b0e91aa8169b4c3881bfd85aacfab23a159f5), [`472e787`](https://github.com/FlanChanXwO/javdb-cli/commit/472e787d49db7925be0987b26a8f967bd76cae85), [`79ab9dd`](https://github.com/FlanChanXwO/javdb-cli/commit/79ab9dd385872d2ba665ec76ac2f79dd7bac45cb), [`af0e834`](https://github.com/FlanChanXwO/javdb-cli/commit/af0e83428c4db92a82bc6d2bd055d294934f2e34), [`aff20fb`](https://github.com/FlanChanXwO/javdb-cli/commit/aff20fb6863d2ef71d02a8672bf3d57dbbdf2f53), [`f6cae5b`](https://github.com/FlanChanXwO/javdb-cli/commit/f6cae5be5a9d9d42553a166442d92f5e5c641060))
+
+## Documentation
+
+- Document the TTY-aware output contract and add focused acceptance coverage for the default text pipeline and producer projections. ([`53d4294`](https://github.com/FlanChanXwO/javdb-cli/commit/53d42949f3f39177b22ac1d9c802ce5651ec7b27), [`728f369`](https://github.com/FlanChanXwO/javdb-cli/commit/728f3695621ecd310e0dc43a815cf171c8b9b1bb), [`180e55a`](https://github.com/FlanChanXwO/javdb-cli/commit/180e55a645969a473de5e794099c57e67c63dfee), [`cfa62f6`](https://github.com/FlanChanXwO/javdb-cli/commit/cfa62f6d86fa81fe269be0bb257d41a4cc00cbf4), [`98ecb82`](https://github.com/FlanChanXwO/javdb-cli/commit/98ecb82c5fa727067c8b9b3abb1bec72dc78bce3))
+
+**Full Changelog**: [v0.7.1...v0.7.2](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.1...v0.7.2)

--- a/changelog/v0.7.2/zh-CN.md
+++ b/changelog/v0.7.2/zh-CN.md
@@ -2,14 +2,10 @@
 
 ## 新增
 
-- 新增 `search --magnets N`、稳定的磁力排序与筛选、以图搜磁力，以及影片和命名实体的逐项管道记录输出。 ([`1054964`](https://github.com/FlanChanXwO/javdb-cli/commit/1054964661f213da0ff392ce680ec6d98cf58028), [`32d8c3c`](https://github.com/FlanChanXwO/javdb-cli/commit/32d8c3c46719c1e900cfb1d22198610cf2d35bdb), [`b8a9ee5`](https://github.com/FlanChanXwO/javdb-cli/commit/b8a9ee5e5655c091095fed4ad49988648e533242), [`ce93242`](https://github.com/FlanChanXwO/javdb-cli/commit/ce932429c98d27cb7dfcb8c345a8fa1a1f0203ca), [`d7c3f93`](https://github.com/FlanChanXwO/javdb-cli/commit/d7c3f93c0400843637cf3383eccfb8e347305db5), [`cd723be`](https://github.com/FlanChanXwO/javdb-cli/commit/cd723be0a8e7f0da4832dea5222aa4ca5f34a2ea))
+- 新增 `search --magnets N`、稳定的磁力排序与筛选、以图搜磁力，以及影片和命名实体的逐项管道记录输出。 ([#29](https://github.com/FlanChanXwO/javdb-cli/pull/29))
 
 ## 修复
 
-- 修复非 TTY producer 输出不可稳定消费、上游错误信封被重复处理、重复影片详情请求，以及部分磁力和输出失败未正确报告的问题。 ([`0fb52c6`](https://github.com/FlanChanXwO/javdb-cli/commit/0fb52c613d412ac71126419dcbf82fcbea450b14), [`23ec4e4`](https://github.com/FlanChanXwO/javdb-cli/commit/23ec4e4e39cc1ae46d238f3949225612b5918909), [`2ab4a75`](https://github.com/FlanChanXwO/javdb-cli/commit/2ab4a7568344f0e1216b71499976a8b9c577c6a5), [`2f9b0e9`](https://github.com/FlanChanXwO/javdb-cli/commit/2f9b0e91aa8169b4c3881bfd85aacfab23a159f5), [`472e787`](https://github.com/FlanChanXwO/javdb-cli/commit/472e787d49db7925be0987b26a8f967bd76cae85), [`79ab9dd`](https://github.com/FlanChanXwO/javdb-cli/commit/79ab9dd385872d2ba665ec76ac2f79dd7bac45cb), [`af0e834`](https://github.com/FlanChanXwO/javdb-cli/commit/af0e83428c4db92a82bc6d2bd055d294934f2e34), [`aff20fb`](https://github.com/FlanChanXwO/javdb-cli/commit/aff20fb6863d2ef71d02a8672bf3d57dbbdf2f53), [`f6cae5b`](https://github.com/FlanChanXwO/javdb-cli/commit/f6cae5be5a9d9d42553a166442d92f5e5c641060))
-
-## 文档
-
-- 补充 TTY 感知的输出契约，并为默认文本管道和 producer 投影增加聚焦验收覆盖。 ([`53d4294`](https://github.com/FlanChanXwO/javdb-cli/commit/53d42949f3f39177b22ac1d9c802ce5651ec7b27), [`728f369`](https://github.com/FlanChanXwO/javdb-cli/commit/728f3695621ecd310e0dc43a815cf171c8b9b1bb), [`180e55a`](https://github.com/FlanChanXwO/javdb-cli/commit/180e55a645969a473de5e794099c57e67c63dfee), [`cfa62f6`](https://github.com/FlanChanXwO/javdb-cli/commit/cfa62f6d86fa81fe269be0bb257d41a4cc00cbf4), [`98ecb82`](https://github.com/FlanChanXwO/javdb-cli/commit/98ecb82c5fa727067c8b9b3abb1bec72dc78bce3))
+- 修复非 TTY producer 输出不可稳定消费、上游错误信封被重复处理、重复影片详情请求，以及部分磁力和输出失败未正确报告的问题，并让真实 API 冒烟检查与输出契约一致。 ([#29](https://github.com/FlanChanXwO/javdb-cli/pull/29))
 
 **完整变更**：[v0.7.1...v0.7.2](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.1...v0.7.2)

--- a/changelog/v0.7.2/zh-CN.md
+++ b/changelog/v0.7.2/zh-CN.md
@@ -1,0 +1,15 @@
+# v0.7.2 — 2026-08-16
+
+## 新增
+
+- 新增 `search --magnets N`、稳定的磁力排序与筛选、以图搜磁力，以及影片和命名实体的逐项管道记录输出。 ([`1054964`](https://github.com/FlanChanXwO/javdb-cli/commit/1054964661f213da0ff392ce680ec6d98cf58028), [`32d8c3c`](https://github.com/FlanChanXwO/javdb-cli/commit/32d8c3c46719c1e900cfb1d22198610cf2d35bdb), [`b8a9ee5`](https://github.com/FlanChanXwO/javdb-cli/commit/b8a9ee5e5655c091095fed4ad49988648e533242), [`ce93242`](https://github.com/FlanChanXwO/javdb-cli/commit/ce932429c98d27cb7dfcb8c345a8fa1a1f0203ca), [`d7c3f93`](https://github.com/FlanChanXwO/javdb-cli/commit/d7c3f93c0400843637cf3383eccfb8e347305db5), [`cd723be`](https://github.com/FlanChanXwO/javdb-cli/commit/cd723be0a8e7f0da4832dea5222aa4ca5f34a2ea))
+
+## 修复
+
+- 修复非 TTY producer 输出不可稳定消费、上游错误信封被重复处理、重复影片详情请求，以及部分磁力和输出失败未正确报告的问题。 ([`0fb52c6`](https://github.com/FlanChanXwO/javdb-cli/commit/0fb52c613d412ac71126419dcbf82fcbea450b14), [`23ec4e4`](https://github.com/FlanChanXwO/javdb-cli/commit/23ec4e4e39cc1ae46d238f3949225612b5918909), [`2ab4a75`](https://github.com/FlanChanXwO/javdb-cli/commit/2ab4a7568344f0e1216b71499976a8b9c577c6a5), [`2f9b0e9`](https://github.com/FlanChanXwO/javdb-cli/commit/2f9b0e91aa8169b4c3881bfd85aacfab23a159f5), [`472e787`](https://github.com/FlanChanXwO/javdb-cli/commit/472e787d49db7925be0987b26a8f967bd76cae85), [`79ab9dd`](https://github.com/FlanChanXwO/javdb-cli/commit/79ab9dd385872d2ba665ec76ac2f79dd7bac45cb), [`af0e834`](https://github.com/FlanChanXwO/javdb-cli/commit/af0e83428c4db92a82bc6d2bd055d294934f2e34), [`aff20fb`](https://github.com/FlanChanXwO/javdb-cli/commit/aff20fb6863d2ef71d02a8672bf3d57dbbdf2f53), [`f6cae5b`](https://github.com/FlanChanXwO/javdb-cli/commit/f6cae5be5a9d9d42553a166442d92f5e5c641060))
+
+## 文档
+
+- 补充 TTY 感知的输出契约，并为默认文本管道和 producer 投影增加聚焦验收覆盖。 ([`53d4294`](https://github.com/FlanChanXwO/javdb-cli/commit/53d42949f3f39177b22ac1d9c802ce5651ec7b27), [`728f369`](https://github.com/FlanChanXwO/javdb-cli/commit/728f3695621ecd310e0dc43a815cf171c8b9b1bb), [`180e55a`](https://github.com/FlanChanXwO/javdb-cli/commit/180e55a645969a473de5e794099c57e67c63dfee), [`cfa62f6`](https://github.com/FlanChanXwO/javdb-cli/commit/cfa62f6d86fa81fe269be0bb257d41a4cc00cbf4), [`98ecb82`](https://github.com/FlanChanXwO/javdb-cli/commit/98ecb82c5fa727067c8b9b3abb1bec72dc78bce3))
+
+**完整变更**：[v0.7.1...v0.7.2](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.1...v0.7.2)

--- a/docs/en/cli-reference.md
+++ b/docs/en/cli-reference.md
@@ -79,6 +79,7 @@ TOP250 and personal-list commands require the default account.
 ```bash
 javdb search KEYWORD|IMAGE [--zone ZONE] [--sort SORT] [--filter-by FILTER] \
   [--type TYPE] [--page N] [--limit N] [--has-magnets] \
+  [--magnets N] [--cnsub] [--hd] [--min-size SIZE] \
   [--image] [--source NAME] [--no-cache] [--json|--ndjson]
 javdb detail NUMBER [--id] [--magnets] [--json|--ndjson]
 javdb comments NUMBER [--id] [--page N] [--limit N] [--json|--ndjson]
@@ -99,6 +100,13 @@ shared by the commands above and below.
 `browse --tag` accepts a tag ID, English name, or Chinese name. Repeat
 `--main` for server-side category masks. Use `--json` for programs; human output
 uses tab-separated rows and is not a stable machine schema.
+
+`search --magnets N` fetches magnets for each result movie: `--cnsub`,
+`--hd`, and `--min-size` filter before ranking; `N` controls how many
+magnets to keep per movie (`0` = all, `N` = top N by best rule). Text
+output emits magnet URIs; `--ndjson` emits `kind=magnet` envelopes.
+`--magnets` is only supported for movie search and is mutually exclusive
+with non-movie `--type`.
 
 `comments` calls the movie reviews endpoint exactly once for the selected page;
 it never prefetches or follows another page. Its default is page `1` with a

--- a/docs/en/cli-reference.md
+++ b/docs/en/cli-reference.md
@@ -200,12 +200,13 @@ Consumers check the kind strictly and prefer a valid `id`; incompatible input
 becomes an in-place `error` envelope. Batch processing preserves input order,
 continues after item failures, and exits non-zero with a summary on stderr.
 
-Output defaults to human-readable text. `--ndjson` and `--json` are mutually
+TTY stdout defaults to human-readable text; non-TTY stdout defaults to a
+stable, newline-delimited record stream. `--ndjson` and `--json` are mutually
 exclusive; JSON or NDJSON is emitted only when its flag is explicit.
 `--json` keeps the legacy single-item shape and emits a JSON array of envelopes
 for batch input. Producers (e.g. `browse`, `tags`, `lists`, `rankings`,
-`top250`, `watched`, `want`, `recent`) never read stdin and also default to
-text; use `--ndjson` to emit one envelope per record.
+`top250`, `watched`, `want`, `recent`) never read stdin and follow the same
+TTY/non-TTY text split; use `--ndjson` to emit one envelope per record.
 
 ## Entity and list navigation
 

--- a/docs/en/sdk.md
+++ b/docs/en/sdk.md
@@ -97,7 +97,7 @@ log, panic, error wrapper, or test fixture.
 | Reviews | `MovieComments` |
 | Local media downloads | `DownloadMovieMedia`, `MovieMediaDownloadOptions`, `MovieMediaDownloadResult` |
 | Entity graph | `ResolveEntity`, `EntityDetail`, `EntityMovies`, `AllEntityMovies` |
-| Magnets | `MovieMagnets`, `FilterMagnets`, `PickBestMagnet`, `MagnetURI` |
+| Magnets | `MovieMagnets`, `FilterMagnets`, `PickBestMagnet`, `RankMagnets`, `MagnetURI` |
 | Rankings | `RankingsMovies`, `RankingsActors`, `RankingsPlayback`, `Top250` |
 | Personal state | `WatchedMovies`, `WantMovies`, `Mark`, `Unmark`, `Collected`, `RecentViewed` |
 | Lists | `MyLists`, `ListInfo`, `RelatedLists` |
@@ -195,7 +195,10 @@ for _, match := range result.Matches {
 - `SearchByImage` runs strict, case-insensitive, full-equality number matching
   (`ResolveMovieIDExact` — no first-hit fallback) for every candidate
   concurrently and restores provider order; per-candidate failures are
-  `ImageSearchError` values and never abort the batch.
+  `ImageSearchError` values and never abort the batch. Set
+  `ImageSearchOptions{SkipMovieDetail: true}` to resolve only the movie ID
+  without fetching full details — useful when only the ID is needed (e.g.
+  magnet lookups).
 - `ReverseSearchCache` is an injectable interface (`Get`/`Put` keyed by
   `"<source>:<image SHA-256>"` so different providers never share entries);
   the SDK never reads `~/.javdb-cli`. A cache hit skips the provider;

--- a/docs/maintainers/architecture.md
+++ b/docs/maintainers/architecture.md
@@ -143,9 +143,11 @@ adapter，统一 multipart `file` 响应协议、三次总请求与 30/60s 退�
 
 `javdb.pipeline/v1` 机器协议核心：typed envelope（schema/kind/ref/id/data/
 meta）、严格 NDJSON 与逐行文本解码、输入分类（图片 magic → NDJSON → 文本）、
-输出模式（默认文本 / 显式 --ndjson/--json 互斥，单/批 JSON
-cardinality）、批处理执行（顺序保持、原位错误信封、最终非零），以及
-Consumer/BatchRunner/ListProducer 三件套把只读/状态命令统一接入。命令不
+输出模式（TTY 默认 OutputHuman 人类文本 / 非 TTY 默认 OutputText 稳定记录流 /
+显式 --ndjson/--json 互斥，单/批 JSON cardinality）、批处理执行（顺序保持、
+原位错误信封、最终非零；Concurrency > 0 时按输入并发并保序写出）、
+Consumer/BatchRunner/ListProducer 三件套把只读/状态命令统一接入。RunMany
+支持单项 fan-out（如 movie 搜索按影片展开）。命令不
 复制解析逻辑；`auth login` 与密码提示排除通用 stdin。
 
 ### `internal/update`

--- a/docs/zh-CN/cli-reference.md
+++ b/docs/zh-CN/cli-reference.md
@@ -66,6 +66,7 @@ token 时自动携带，失效则回退匿名）；TOP250 和个人列表命令�
 ```bash
 javdb search KEYWORD|IMAGE [--zone ZONE] [--sort SORT] [--filter-by FILTER] \
   [--type TYPE] [--page N] [--limit N] [--has-magnets] \
+  [--magnets N] [--cnsub] [--hd] [--min-size SIZE] \
   [--image] [--source NAME] [--no-cache] [--json|--ndjson]
 javdb detail NUMBER [--id] [--magnets] [--json|--ndjson]
 javdb comments NUMBER [--id] [--page N] [--limit N] [--json|--ndjson]
@@ -80,6 +81,11 @@ javdb browse [--zone ZONE] [--tag REF]... [--main FLAG]... [--year YYYY] \
 
 `browse --tag` 接受 tag ID、英文名或中文名；`--main` 可重复传递服务端分类掩码。
 程序应使用 `--json`；制表符文本面向人阅读，不是稳定机器 schema。
+
+`search --magnets N` 为每部搜索结果影片获取磁力：`--cnsub`、`--hd`、`--min-size`
+在排序前筛选；`N` 控制每部影片保留的磁力数量（`0` = 全部，`N` = 按 best 规则取前 N）。
+文本模式输出磁力 URI；`--ndjson` 输出 `kind=magnet` 信封。`--magnets` 仅支持 movie
+搜索，与非 movie `--type` 互斥。
 
 `comments` 对所选页只调用一次影片评论接口，不会预取或自动跟随下一页。默认读取第 `1` 页、
 每页 `20` 条；需要其他**单页**时传入任意正数 `--page` 与 `--limit`。`--json` 会保留该页

--- a/docs/zh-CN/cli-reference.md
+++ b/docs/zh-CN/cli-reference.md
@@ -161,10 +161,11 @@ SDK 嵌入方必须自行施加网络边界。
 消费者严格检查 kind 并优先使用合法 `id`；不兼容输入生成原位 `error` 信封。批处理保持输入
 顺序、单项失败继续执行，最终非零并在 stderr 输出汇总。
 
-输出默认使用人类可读文本。`--ndjson` 与 `--json` 互斥；只有显式指定对应 flag
-才输出 JSON 或 NDJSON。显式 `--json` 单项保持既有 shape，多项输出信封数组。生产者命令
+TTY stdout 默认使用人类可读文本；非 TTY stdout 默认输出逐行稳定记录流。`--ndjson` 与
+`--json` 互斥；只有显式指定对应 flag 才输出 JSON 或 NDJSON。显式 `--json` 单项保持既有
+shape，多项输出信封数组。生产者命令
 （如 `browse`、`tags`、`lists`、`rankings`、`top250`、`watched`、`want`、`recent`）
-不读 stdin 且同样默认文本；使用 `--ndjson` 才逐条输出信封。
+不读 stdin，且遵循相同的 TTY/非 TTY 文本分流；使用 `--ndjson` 才逐条输出信封。
 
 ## 实体与合集导航
 

--- a/docs/zh-CN/sdk.md
+++ b/docs/zh-CN/sdk.md
@@ -89,7 +89,7 @@ userID, username, err := client.ResolveUserID(ctx)
 | 评论 | `MovieComments` |
 | 本地媒体下载 | `DownloadMovieMedia`、`MovieMediaDownloadOptions`、`MovieMediaDownloadResult` |
 | 实体图 | `ResolveEntity`、`EntityDetail`、`EntityMovies`、`AllEntityMovies` |
-| 磁力 | `MovieMagnets`、`FilterMagnets`、`PickBestMagnet`、`MagnetURI` |
+| 磁力 | `MovieMagnets`、`FilterMagnets`、`PickBestMagnet`、`RankMagnets`、`MagnetURI` |
 | 排行 | `RankingsMovies`、`RankingsActors`、`RankingsPlayback`、`Top250` |
 | 个人状态 | `WatchedMovies`、`WantMovies`、`Mark`、`Unmark`、`Collected`、`RecentViewed` |
 | 合集 | `MyLists`、`ListInfo`、`RelatedLists` |
@@ -174,7 +174,8 @@ for _, match := range result.Matches {
   HTTP(S) source），返回规范化候选与帧；multipart 字段固定为 `file`。
 - `SearchByImage` 对每个候选并发执行大小写不敏感、完整相等的严格番号匹配
   （`ResolveMovieIDExact`，不回退首项）并恢复 provider 顺序；单候选失败是
-  `ImageSearchError`，绝不中止整批。
+  `ImageSearchError`，绝不中止整批。设置 `ImageSearchOptions{SkipMovieDetail: true}`
+  可仅解析 movie ID 而不获取完整详情——适用于只需 ID 的场景（如磁力查询）。
 - `ReverseSearchCache` 是可注入接口（`Get`/`Put` 的 key 为
   `"<source>:<原图 SHA-256>"`，不同 provider 永不共享条目）；SDK 绝不读取
   `~/.javdb-cli`。缓存命中跳过 provider，`BypassCache` 按请求禁用。缓存不得

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -33,6 +33,15 @@ assert_substring() {
   fi
 }
 
+assert_nonempty() {
+  local label="$1" haystack="$2"
+  if [ -n "$haystack" ]; then
+    printf '  ok   %s\n' "$label"; PASS=$((PASS+1))
+  else
+    printf '  FAIL %s: output is empty\n' "$label"; FAIL=$((FAIL+1))
+  fi
+}
+
 # assert_json <label> <json> <python-expr-returning-bool>
 assert_json() {
   local label="$1" json="$2" expr="$3"
@@ -71,15 +80,15 @@ assert_json "search --ndjson emits a pipeline envelope" "$nout" "d.get('schema')
 
 echo "== rankings =="
 out=$(run rankings movies --period week)
-assert_substring "rankings movies week has a row" "$out" $'\t'
+assert_nonempty "rankings movies week has a stable ref" "$out"
 out=$(run rankings actors --period week)
-assert_substring "rankings actors week has tab row" "$out" $'\t'
+assert_nonempty "rankings actors week has a stable ref" "$out"
 out=$(run rankings playback --period week)
-assert_substring "rankings playback week has a row" "$out" $'\t'
+assert_nonempty "rankings playback week has a stable ref" "$out"
 
 echo "== browse =="
 out=$(run browse --zone censored --limit 1)
-assert_substring "browse returns a movie row" "$out" $'\t'
+assert_nonempty "browse returns a stable movie ref" "$out"
 
 echo "== detail (image fields) =="
 out=$(run detail SSIS-001)
@@ -92,7 +101,7 @@ assert_json "detail --json exposes cover_url key" "$jout" "'cover_url' in d"
 
 echo "== tags =="
 out=$(run tags --zone censored)
-assert_substring "tags lists main header" "$out" "main"
+assert_substring "tags lists a stable tag ref" "$out" "Playable"
 
 echo "== magnets (read-only; uses token if available) =="
 jout=$(run magnets SSIS-001 --best --json)

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -125,17 +125,17 @@ else
 
   echo "== top250 =="
   out=$(run top250 --zone censored --limit 1)
-  assert_substring "top250 has ranked row" "$out" "#1"
+  assert_nonempty "top250 has a stable movie ref" "$out"
   out=$(run top250 --zone censored --limit 1 --json)
   assert_json "top250 --json ok" "$out" "'movies' in d and len(d['movies']) == 1"
 
   echo "== watched / want / recent =="
   out=$(run watched)
-  assert_substring "watched returns rows" "$out" $'\t'
+  assert_nonempty "watched returns stable movie refs" "$out"
   out=$(run want)
-  assert_substring "want returns rows" "$out" $'\t'
+  assert_nonempty "want returns stable movie refs" "$out"
   out=$(run recent)
-  assert_substring "recent returns rows" "$out" $'\t'
+  assert_nonempty "recent returns stable movie refs" "$out"
 
   echo "== collections =="
   out=$(run collections actors)
@@ -143,7 +143,7 @@ else
 
   echo "== lists =="
   out=$(run lists --limit 1)
-  assert_substring "lists has row" "$out" $'\t'
+  assert_nonempty "lists has a stable list ref" "$out"
 
   echo "== entity filmography =="
   out=$(run actor 葵つかさ --limit 1)

--- a/internal/cli/commands/lists/lists_test.go
+++ b/internal/cli/commands/lists/lists_test.go
@@ -2,9 +2,13 @@ package lists
 
 import (
 	"bytes"
-	"github.com/FlanChanXwO/javdb-cli/internal/cli/invocation"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/FlanChanXwO/javdb-cli/internal/cli/invocation"
 )
 
 func TestNewBuildsListsGroup(t *testing.T) {
@@ -26,6 +30,39 @@ func TestNewBuildsListsGroup(t *testing.T) {
 		if !got[name] {
 			t.Fatalf("lists missing subcommand %q", name)
 		}
+	}
+}
+
+func TestNewTextAndHumanOutputModes(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/lists" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": true, "data": map[string]any{
+			"lists": []map[string]any{{"id": "list-1", "name": "My List", "movies_count": float64(2), "privacy": "public", "views_count": float64(5)}},
+		}})
+	}))
+	defer server.Close()
+
+	textStreams := invocation.NewStreams(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	textCmd := New(&invocation.RootOptions{Host: server.URL}, textStreams)
+	if err := textCmd.Execute(); err != nil {
+		t.Fatalf("text execute: %v", err)
+	}
+	if got := textStreams.Out.(*bytes.Buffer).String(); got != "My List\n" {
+		t.Fatalf("non-TTY output = %q, want stable ref", got)
+	}
+
+	humanStreams := invocation.NewStreams(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	humanStreams.OutIsTerminal = true
+	humanCmd := New(&invocation.RootOptions{Host: server.URL}, humanStreams)
+	if err := humanCmd.Execute(); err != nil {
+		t.Fatalf("human execute: %v", err)
+	}
+	if got := humanStreams.Out.(*bytes.Buffer).String(); got != "list-1\tMy List\t2\tpublic\t5\n" {
+		t.Fatalf("TTY output = %q, want list table", got)
 	}
 }
 

--- a/internal/cli/commands/magnets/magnets.go
+++ b/internal/cli/commands/magnets/magnets.go
@@ -63,8 +63,11 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 			return client.NewWithDefaultToken(options)
 		},
 		RunOne: func(c *javdb.Client, ctx context.Context, input pipeline.Envelope) (pipeline.Envelope, error) {
+			// 管道信封携带 id 时直接按内部 ID 请求，不做番号解析。
+			// --id flag 仅对位置参数（无信封 id）生效。
+			useID := input.ID != "" || isID
 			ref := pipeline.ConsumerRef(input)
-			mid, items, err := fetch(c, ctx, ref, isID && input.ID == "")
+			mid, items, err := fetch(c, ctx, ref, useID)
 			if err != nil {
 				return pipeline.Envelope{}, err
 			}

--- a/internal/cli/commands/magnets/magnets.go
+++ b/internal/cli/commands/magnets/magnets.go
@@ -23,24 +23,35 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 		asJSON, asNDJSON      bool
 		minSize               string
 	)
-	fetch := func(c *javdb.Client, ctx context.Context, ref string, useID bool) (string, []map[string]any, error) {
-		mid := ref
+	fetch := func(c *javdb.Client, ctx context.Context, input pipeline.Envelope, useID bool) (string, []map[string]any, error) {
+		mid := pipeline.ConsumerRef(input)
 		var err error
 		if !useID {
-			mid, err = c.ResolveMovieID(ctx, ref)
+			mid, err = c.ResolveMovieID(ctx, mid)
 			if err != nil {
 				return "", nil, err
 			}
 		}
-		detail, err := c.MovieDetail(ctx, mid)
-		if err != nil {
-			return "", nil, fmt.Errorf("magnets failed: %w", err)
-		}
+		// 若输入信封已携带 magnets_count，跳过重复 MovieDetail 请求。
+		count, hasCount := knownMagnetCount(input)
 		var items []map[string]any
-		if magnetCount(detail["magnets_count"]) == 0 {
+		if hasCount && count == 0 {
 			items = nil
 		} else {
-			items, err = c.MovieMagnets(ctx, mid)
+			if hasCount {
+				// magnets_count > 0：直接取磁力，不做详情请求。
+				items, err = c.MovieMagnets(ctx, mid)
+			} else {
+				detail, derr := c.MovieDetail(ctx, mid)
+				if derr != nil {
+					return "", nil, fmt.Errorf("magnets failed: %w", derr)
+				}
+				if magnetCount(detail["magnets_count"]) == 0 {
+					items = nil
+				} else {
+					items, err = c.MovieMagnets(ctx, mid)
+				}
+			}
 			if err != nil {
 				return "", nil, fmt.Errorf("magnets failed: %w", err)
 			}
@@ -59,6 +70,8 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 		Name:       "magnets",
 		LegacyJSON: true,
 		Kinds:      []pipeline.Kind{pipeline.KindMovie},
+		// 按输入并发请求磁力；结果按输入顺序写出。
+		Concurrency: 1,
 		ClientFactory: func() (*javdb.Client, error) {
 			return client.NewWithDefaultToken(options)
 		},
@@ -66,8 +79,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 			// 管道信封携带 id 时直接按内部 ID 请求，不做番号解析。
 			// --id flag 仅对位置参数（无信封 id）生效。
 			useID := input.ID != "" || isID
-			ref := pipeline.ConsumerRef(input)
-			mid, items, err := fetch(c, ctx, ref, useID)
+			mid, items, err := fetch(c, ctx, input, useID)
 			if err != nil {
 				return pipeline.Envelope{}, err
 			}
@@ -82,7 +94,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 		Legacy: func(args []string) error {
 			return client.WithOptionalAuth(options, streams.Err, func(c *javdb.Client) error {
 				ctx := context.Background()
-				mid, items, err := fetch(c, ctx, args[0], isID)
+				mid, items, err := fetch(c, ctx, pipeline.New("", args[0], ""), isID)
 				if err != nil {
 					return err
 				}
@@ -169,4 +181,22 @@ func magnetCount(v any) int {
 		}
 		return 0
 	}
+}
+
+// knownMagnetCount 从输入信封中提取已知的 magnets_count（上游 search 信封的
+// data.movie 携带该字段时可用）。返回 (count, true) 表示已知，(0, false) 表示
+// 未知，需要请求 MovieDetail。
+func knownMagnetCount(input pipeline.Envelope) (int, bool) {
+	if input.Data == nil {
+		return 0, false
+	}
+	movie, ok := input.Data["movie"].(map[string]any)
+	if !ok {
+		return 0, false
+	}
+	raw, exists := movie["magnets_count"]
+	if !exists {
+		return 0, false
+	}
+	return magnetCount(raw), true
 }

--- a/internal/cli/commands/magnets/magnets.go
+++ b/internal/cli/commands/magnets/magnets.go
@@ -76,7 +76,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 			return renderText(w, envelope, best)
 		},
 		Kinds: []pipeline.Kind{pipeline.KindMovie},
-		// 按输入并发请求磁力；结果按输入顺序写出。
+		// 逐项请求磁力并按输入顺序写出；保持串行以避免放大 API 请求。
 		Concurrency: 1,
 		ClientFactory: func() (*javdb.Client, error) {
 			return client.NewWithDefaultToken(options)
@@ -133,6 +133,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 		Short: "List magnet links for a movie",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			runner.Context = cmd.Context()
 			return runner.Execute(streams, args, asNDJSON, asJSON)
 		},
 	}

--- a/internal/cli/commands/magnets/magnets.go
+++ b/internal/cli/commands/magnets/magnets.go
@@ -4,6 +4,7 @@ package magnets
 import (
 	"context"
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 
@@ -69,7 +70,12 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	runner := &pipeline.BatchRunner{
 		Name:       "magnets",
 		LegacyJSON: true,
-		Kinds:      []pipeline.Kind{pipeline.KindMovie},
+		// 非 TTY 单项也输出可供下游消费的磁力 URI。
+		RouteTextThroughPipeline: true,
+		RenderText: func(w io.Writer, envelope pipeline.Envelope) error {
+			return renderText(w, envelope, best)
+		},
+		Kinds: []pipeline.Kind{pipeline.KindMovie},
 		// 按输入并发请求磁力；结果按输入顺序写出。
 		Concurrency: 1,
 		ClientFactory: func() (*javdb.Client, error) {
@@ -138,6 +144,30 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Machine-readable JSON")
 	cmd.Flags().BoolVar(&asNDJSON, "ndjson", false, "Pipeline NDJSON envelopes")
 	return cmd
+}
+
+// renderText 将磁力信封投影为可继续传给下游的 magnet URI；不把人类表格列
+// 混入 stdout，也不吞写入错误。
+func renderText(w io.Writer, envelope pipeline.Envelope, best bool) error {
+	if best {
+		uri, _ := envelope.Data["magnet_uri"].(string)
+		if uri == "" {
+			return nil
+		}
+		_, err := fmt.Fprintln(w, uri)
+		return err
+	}
+	magnets, _ := envelope.Data["magnets"].([]map[string]any)
+	for _, magnet := range magnets {
+		uri := javdb.MagnetURI(magnet)
+		if uri == "" {
+			continue
+		}
+		if _, err := fmt.Fprintln(w, uri); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // ParseSizeMiB parses the CLI magnet size filter without changing its unit rules.

--- a/internal/cli/commands/magnets/magnets_test.go
+++ b/internal/cli/commands/magnets/magnets_test.go
@@ -2,9 +2,14 @@ package magnets
 
 import (
 	"bytes"
-	"github.com/FlanChanXwO/javdb-cli/internal/cli/invocation"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/FlanChanXwO/javdb-cli/internal/cli/invocation"
 )
 
 func TestNewHelpListsFlags(t *testing.T) {
@@ -47,5 +52,153 @@ func TestWriteMagnetsEmpty(t *testing.T) {
 	writeMagnets(&out, &errb, nil)
 	if out.String() != "" || errb.String() != "(无磁力链)\n" {
 		t.Fatalf("out=%q err=%q", out.String(), errb.String())
+	}
+}
+
+// TestMagnetsNDJSONInputWithIDDirect NDJSON 信封携带 id 时直接按 ID 请求，
+// 不做番号解析。
+func TestMagnetsNDJSONInputWithIDDirect(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	t.Setenv("HOMEDRIVE", filepath.VolumeName(t.TempDir()))
+	t.Setenv("HOMEPATH", strings.TrimPrefix(t.TempDir(), filepath.VolumeName(t.TempDir())))
+	resolved := false
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v2/search":
+			resolved = true
+			_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{"movies": []map[string]any{}}})
+		case "/api/v4/movies/id-xyz":
+			_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{"movie": map[string]any{"magnets_count": float64(2)}}})
+		case "/api/v1/movies/id-xyz/magnets":
+			_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{
+				"magnets": []map[string]any{
+					{"name": "HD", "hash": "AAA", "size": float64(4096), "hd": true},
+					{"name": "SD", "hash": "BBB", "size": float64(64)},
+				},
+			}})
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	// NDJSON 信封携带 id → 直接按 ID 请求，不调用 search。
+	streams := invocation.NewStreams(
+		strings.NewReader("{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"movie\",\"ref\":\"SSIS-001\",\"id\":\"id-xyz\"}\n"),
+		&bytes.Buffer{}, &bytes.Buffer{},
+	)
+	cmd := New(&invocation.RootOptions{Host: server.URL}, streams)
+	cmd.SetArgs([]string{"--ndjson"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if resolved {
+		t.Error("ResolveMovieID (search) must not be called when envelope carries id")
+	}
+	out := streams.Out.(*bytes.Buffer).String()
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if envelope["kind"] != "magnet" {
+		t.Errorf("kind = %v, want magnet", envelope["kind"])
+	}
+	if envelope["id"] != "id-xyz" {
+		t.Errorf("id = %v, want id-xyz", envelope["id"])
+	}
+}
+
+// TestMagnetsTextModeOutputsMagnetURIs 文本模式输出磁力 URI，而非番号 ref。
+func TestMagnetsTextModeOutputsMagnetURIs(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	t.Setenv("HOMEDRIVE", filepath.VolumeName(t.TempDir()))
+	t.Setenv("HOMEPATH", strings.TrimPrefix(t.TempDir(), filepath.VolumeName(t.TempDir())))
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v4/movies/id-1":
+			_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{"movie": map[string]any{"magnets_count": float64(2)}}})
+		case "/api/v1/movies/id-1/magnets":
+			_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{
+				"magnets": []map[string]any{
+					{"name": "HD", "hash": "AAA", "size": float64(4096), "hd": true},
+					{"name": "SD", "hash": "BBB", "size": float64(64)},
+				},
+			}})
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	streams := invocation.NewStreams(
+		strings.NewReader("{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"movie\",\"ref\":\"SSIS-001\",\"id\":\"id-1\"}\n"),
+		&bytes.Buffer{}, &bytes.Buffer{},
+	)
+	cmd := New(&invocation.RootOptions{Host: server.URL}, streams)
+	cmd.SetArgs([]string{"--ndjson"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	out := streams.Out.(*bytes.Buffer).String()
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if envelope["kind"] != "magnet" {
+		t.Errorf("kind = %v, want magnet", envelope["kind"])
+	}
+	data, _ := envelope["data"].(map[string]any)
+	magnets, _ := data["magnets"].([]any)
+	if len(magnets) != 2 {
+		t.Errorf("magnets count = %d, want 2", len(magnets))
+	}
+}
+
+// TestMagnetsPartialFailureContinues NDJSON 批处理中部分项失败仍继续。
+func TestMagnetsPartialFailureContinues(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	t.Setenv("HOMEDRIVE", filepath.VolumeName(t.TempDir()))
+	t.Setenv("HOMEPATH", strings.TrimPrefix(t.TempDir(), filepath.VolumeName(t.TempDir())))
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v4/movies/id-ok":
+			_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{"movie": map[string]any{"magnets_count": float64(1)}}})
+		case "/api/v1/movies/id-ok/magnets":
+			_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{
+				"magnets": []map[string]any{{"name": "HD", "hash": "AAA", "size": float64(4096)}},
+			}})
+		case "/api/v4/movies/id-fail":
+			http.NotFound(writer, request)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	ndjsonInput := "{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"movie\",\"ref\":\"OK\",\"id\":\"id-ok\"}\n" +
+		"{\"schema\":\"javdb.pipeline/v1\",\"kind\":\"movie\",\"ref\":\"FAIL\",\"id\":\"id-fail\"}\n"
+	streams := invocation.NewStreams(strings.NewReader(ndjsonInput), &bytes.Buffer{}, &bytes.Buffer{})
+	cmd := New(&invocation.RootOptions{Host: server.URL}, streams)
+	cmd.SetArgs([]string{"--ndjson"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "1 of 2 items failed") {
+		t.Fatalf("expected 1-of-2 failure, got %v", err)
+	}
+	out := streams.Out.(*bytes.Buffer).String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("lines = %d, want 2", len(lines))
+	}
+	var first, second map[string]any
+	json.Unmarshal([]byte(lines[0]), &first)
+	json.Unmarshal([]byte(lines[1]), &second)
+	if first["kind"] != "magnet" {
+		t.Errorf("line 0 kind = %v, want magnet", first["kind"])
+	}
+	if second["kind"] != "error" {
+		t.Errorf("line 1 kind = %v, want error", second["kind"])
 	}
 }

--- a/internal/cli/commands/magnets/magnets_test.go
+++ b/internal/cli/commands/magnets/magnets_test.go
@@ -156,6 +156,42 @@ func TestMagnetsTextModeOutputsMagnetURIs(t *testing.T) {
 	}
 }
 
+// TestMagnetsPositionalTextModeOutputsMagnetURIs 覆盖纯文本位置参数的真实
+// 非 TTY 路径，确保 stdout 是 magnet URI 而不是输入番号或人类表格行。
+func TestMagnetsPositionalTextModeOutputsMagnetURIs(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	t.Setenv("HOMEDRIVE", filepath.VolumeName(t.TempDir()))
+	t.Setenv("HOMEPATH", strings.TrimPrefix(t.TempDir(), filepath.VolumeName(t.TempDir())))
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v2/search":
+			_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{
+				"movies": []map[string]any{{"number": "SSIS-001", "id": "id-1"}},
+			}})
+		case "/api/v4/movies/id-1":
+			_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{"movie": map[string]any{"magnets_count": float64(2)}}})
+		case "/api/v1/movies/id-1/magnets":
+			_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{
+				"magnets": []map[string]any{{"name": "HD", "hash": "AAA"}, {"name": "SD", "hash": "BBB"}},
+			}})
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	streams := invocation.NewStreams(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	cmd := New(&invocation.RootOptions{Host: server.URL}, streams)
+	cmd.SetArgs([]string{"SSIS-001"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got := streams.Out.(*bytes.Buffer).String(); got != "magnet:?xt=urn:btih:AAA\nmagnet:?xt=urn:btih:BBB\n" {
+		t.Fatalf("text output = %q, want magnet URIs", got)
+	}
+}
+
 // TestMagnetsPartialFailureContinues NDJSON 批处理中部分项失败仍继续。
 func TestMagnetsPartialFailureContinues(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())

--- a/internal/cli/commands/magnets/magnets_test.go
+++ b/internal/cli/commands/magnets/magnets_test.go
@@ -229,8 +229,12 @@ func TestMagnetsPartialFailureContinues(t *testing.T) {
 		t.Fatalf("lines = %d, want 2", len(lines))
 	}
 	var first, second map[string]any
-	json.Unmarshal([]byte(lines[0]), &first)
-	json.Unmarshal([]byte(lines[1]), &second)
+	if err := json.Unmarshal([]byte(lines[0]), &first); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(lines[1]), &second); err != nil {
+		t.Fatal(err)
+	}
 	if first["kind"] != "magnet" {
 		t.Errorf("line 0 kind = %v, want magnet", first["kind"])
 	}

--- a/internal/cli/commands/magnets/magnets_test.go
+++ b/internal/cli/commands/magnets/magnets_test.go
@@ -109,8 +109,9 @@ func TestMagnetsNDJSONInputWithIDDirect(t *testing.T) {
 	}
 }
 
-// TestMagnetsTextModeOutputsMagnetURIs 文本模式输出磁力 URI，而非番号 ref。
-func TestMagnetsTextModeOutputsMagnetURIs(t *testing.T) {
+// TestMagnetsNDJSONInputOutputsMagnetEnvelope 验证 NDJSON 输入保持磁力信封输出，
+// 避免名称误导为默认文本模式覆盖。
+func TestMagnetsNDJSONInputOutputsMagnetEnvelope(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("USERPROFILE", t.TempDir())
 	t.Setenv("HOMEDRIVE", filepath.VolumeName(t.TempDir()))

--- a/internal/cli/commands/search/search.go
+++ b/internal/cli/commands/search/search.go
@@ -20,6 +20,7 @@ import (
 	"github.com/FlanChanXwO/javdb-cli/internal/cli/pipeline"
 	"github.com/FlanChanXwO/javdb-cli/internal/cli/result"
 	"github.com/FlanChanXwO/javdb-cli/internal/common/jsonx"
+	"github.com/FlanChanXwO/javdb-cli/internal/common/scalar"
 	"github.com/FlanChanXwO/javdb-cli/internal/reversesearch/image"
 	"github.com/FlanChanXwO/javdb-cli/sdk"
 )
@@ -217,7 +218,7 @@ func runSearchOne(c *javdb.Client, ctx context.Context, input pipeline.Envelope,
 
 // runSearchMany 执行单个关键词搜索并返回多个信封（fan-out）：
 //   - movie 类型：每部影片一个 KindMovie 信封，ref 为番号，id 为内部 ID。
-//   - 其他 --type：回退为单信封（与 runSearchOne 相同）。
+//   - 其他 --type：每个命名实体一个对应 kind 的信封。
 func runSearchMany(c *javdb.Client, ctx context.Context, input pipeline.Envelope, page, limit int, zone, sort, filterBy, typ string, hasMagnets bool) ([]pipeline.Envelope, error) {
 	keyword := pipeline.ConsumerRef(input)
 	opt := javdb.SearchOptions{
@@ -246,12 +247,26 @@ func runSearchMany(c *javdb.Client, ctx context.Context, input pipeline.Envelope
 		}
 		return envelopes, nil
 	}
-	// 非 movie 类型回退为单信封。
-	one, err := runSearchOne(c, ctx, input, page, limit, zone, sort, filterBy, typ, hasMagnets)
-	if err != nil {
-		return nil, err
+	key := searchTypeKey(typ)
+	items := res.Named(key)
+	envelopes := make([]pipeline.Envelope, 0, len(items))
+	for _, item := range items {
+		ref, id := namedEntityRef(item)
+		envelope := pipeline.New(pipeline.Kind(typ), ref, id).WithData(map[string]any{typ: item})
+		envelopes = append(envelopes, envelope)
 	}
-	return []pipeline.Envelope{one}, nil
+	return envelopes, nil
+}
+
+// namedEntityRef 为命名搜索结果选择可读且稳定的引用，同时保留内部 ID。
+func namedEntityRef(item map[string]any) (string, string) {
+	id := scalar.String(item["id"])
+	for _, key := range []string{"name_zht", "name", "code", "number"} {
+		if ref := scalar.String(item[key]); ref != "" {
+			return ref, id
+		}
+	}
+	return id, id
 }
 func runTextSearch(options *invocation.RootOptions, streams *invocation.Streams, keyword string, page, limit int, zone, sort, filterBy, typ string, hasMagnets, asJSON bool) error {
 	c, err := client.New(options, "")
@@ -305,7 +320,7 @@ func runImageSearch(options *invocation.RootOptions, streams *invocation.Streams
 		Filename:    imageBytes.Filename,
 		Source:      setup.Source,
 		BypassCache: noCache,
-	}, javdb.ImageSearchOptions{})
+	}, javdb.ImageSearchOptions{SkipMovieDetail: mode == pipeline.OutputText})
 	if err != nil {
 		// provider 顶层失败：不伪造空结果。
 		return fmt.Errorf("reverse search failed: %w", err)
@@ -508,45 +523,75 @@ func runSearchMagnets(options *invocation.RootOptions, streams *invocation.Strea
 		}
 	}
 
-	// 收集所有搜索结果影片（保留输入顺序）。
-	var allMovies []map[string]any
+	type magnetResult struct {
+		movie         map[string]any
+		magnets       []map[string]any
+		err           error
+		errorEnvelope pipeline.Envelope
+	}
+
+	// 输入校验与搜索结果使用同一保序序列。错误信封不参与搜索，避免放大
+	// 上游失败；非法 kind 也在发出远程请求前转为原位错误。
+	var results []magnetResult
 	for _, input := range inputs {
+		if input.Kind == pipeline.KindError {
+			results = append(results, magnetResult{
+				err:           errors.New(pipelineErrorMessage(input)),
+				errorEnvelope: input,
+			})
+			continue
+		}
+		if input.Kind != "" && input.Kind != pipeline.KindMovie {
+			itemErr := fmt.Errorf("unsupported kind %q", input.Kind)
+			results = append(results, magnetResult{
+				err:           itemErr,
+				errorEnvelope: pipeline.ErrorEnvelope(input, "search", "input", "kind", itemErr.Error()),
+			})
+			continue
+		}
 		keyword := pipeline.ConsumerRef(input)
 		opt := javdb.SearchOptions{
 			Page: page, Limit: limit, Zone: zone, Sort: sort, FilterBy: filterBy, Type: "movie",
 		}
 		res, err := c.Search(context.Background(), keyword, opt)
 		if err != nil {
-			return fmt.Errorf("search failed: %w", err)
+			itemErr := fmt.Errorf("search failed: %w", err)
+			results = append(results, magnetResult{
+				err:           itemErr,
+				errorEnvelope: pipeline.ErrorEnvelope(input, "search", "search", "fetch", itemErr.Error()),
+			})
+			continue
 		}
 		movies := res.Movies()
 		if hasMagnets {
 			movies = result.FilterMoviesWithMagnets(movies)
 		}
-		allMovies = append(allMovies, movies...)
+		for _, movie := range movies {
+			results = append(results, magnetResult{movie: movie})
+		}
 	}
 
 	// 并发获取每部影片的磁力。
-	type magnetResult struct {
-		movie   map[string]any
-		magnets []map[string]any
-		err     error
-	}
-	results := make([]magnetResult, len(allMovies))
 	var wait sync.WaitGroup
-	for i := range allMovies {
+	for i := range results {
+		if results[i].err != nil {
+			continue
+		}
 		wait.Add(1)
 		go func(i int) {
 			defer wait.Done()
-			mid := fmt.Sprint(allMovies[i]["id"])
+			mid := fmt.Sprint(results[i].movie["id"])
 			mags, err := c.MovieMagnets(context.Background(), mid)
 			if err != nil {
-				results[i] = magnetResult{movie: allMovies[i], err: err}
+				results[i].err = err
+				results[i].errorEnvelope = pipeline.ErrorEnvelope(
+					pipeline.New(pipeline.KindMagnet, fmt.Sprint(results[i].movie["number"]), mid),
+					"search", "magnets", "fetch", err.Error(),
+				)
 				return
 			}
 			mags = javdb.FilterMagnets(mags, cnsub, hd, minMiB)
-			mags = javdb.RankMagnets(mags, magnetsCount)
-			results[i] = magnetResult{movie: allMovies[i], magnets: mags}
+			results[i].magnets = javdb.RankMagnets(mags, magnetsCount)
 		}(i)
 	}
 	wait.Wait()
@@ -557,6 +602,11 @@ func runSearchMagnets(options *invocation.RootOptions, streams *invocation.Strea
 	case pipeline.OutputJSON:
 		moviesOut := make([]map[string]any, 0, len(results))
 		for _, r := range results {
+			if r.movie == nil {
+				failures++
+				moviesOut = append(moviesOut, map[string]any{"error": r.err.Error(), "envelope": r.errorEnvelope})
+				continue
+			}
 			entry := map[string]any{
 				"number":  r.movie["number"],
 				"id":      r.movie["id"],
@@ -574,10 +624,17 @@ func runSearchMagnets(options *invocation.RootOptions, streams *invocation.Strea
 	case pipeline.OutputNDJSON:
 		writer := pipeline.NewWriter(streams.Out, pipeline.OutputNDJSON)
 		for _, r := range results {
+			if r.movie == nil {
+				if err := writer.Write(r.errorEnvelope); err != nil {
+					return err
+				}
+				failures++
+				continue
+			}
 			ref := fmt.Sprint(r.movie["number"])
 			id := fmt.Sprint(r.movie["id"])
 			if r.err != nil {
-				if err := writer.Write(pipeline.ErrorEnvelope(pipeline.New(pipeline.KindMagnet, ref, id), "search", "magnets", "fetch", r.err.Error())); err != nil {
+				if err := writer.Write(r.errorEnvelope); err != nil {
 					return err
 				}
 				failures++
@@ -613,6 +670,13 @@ func runSearchMagnets(options *invocation.RootOptions, streams *invocation.Strea
 		return fmt.Errorf("search --magnets completed with %d of %d movies failed", failures, len(results))
 	}
 	return nil
+}
+
+func pipelineErrorMessage(envelope pipeline.Envelope) string {
+	if message := scalar.String(envelope.Data["message"]); message != "" {
+		return message
+	}
+	return "upstream pipeline error"
 }
 
 // runImageSearchMagnets 执行以图搜番并直接获取磁力：使用 SkipMovieDetail 跳过

--- a/internal/cli/commands/search/search.go
+++ b/internal/cli/commands/search/search.go
@@ -49,13 +49,17 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 			if err != nil {
 				return err
 			}
+			if magnets < 0 {
+				return fmt.Errorf("--magnets must be >= 0")
+			}
+			filtersChanged := cmd.Flags().Changed("cnsub") || cmd.Flags().Changed("hd") || cmd.Flags().Changed("min-size")
+			if filtersChanged && !cmd.Flags().Changed("magnets") {
+				return fmt.Errorf("--cnsub, --hd, and --min-size require --magnets")
+			}
 			// --magnets 仅支持 movie 搜索。
 			if magnets > 0 || cmd.Flags().Changed("magnets") {
 				if typ != "" && typ != "movie" {
 					return fmt.Errorf("--magnets is only supported for movie search (got --type %q)", typ)
-				}
-				if !cmd.Flags().Changed("cnsub") && !cmd.Flags().Changed("hd") && !cmd.Flags().Changed("min-size") && magnets == 0 {
-					// --magnets 0 不配合筛选 flag 时仍允许（返回全部磁力）。
 				}
 			}
 			reader := bufio.NewReader(streams.In)

--- a/internal/cli/commands/search/search.go
+++ b/internal/cli/commands/search/search.go
@@ -330,8 +330,17 @@ func runImageSearch(options *invocation.RootOptions, streams *invocation.Streams
 				return err
 			}
 		}
-	default:
-		if err := writeImageSearchText(streams.Out, result); err != nil {
+	case pipeline.OutputHuman:
+		if err := writeImageSearchText(streams.Out, streams.Err, result); err != nil {
+			return err
+		}
+	case pipeline.OutputText:
+		// 非 TTY stdout 只输出成功影片番号；候选、帧和失败诊断全部写 stderr，
+		// 避免下游 magnets 将人类描述误当作输入番号。
+		if err := writeImageSearchRecords(streams.Out, result); err != nil {
+			return err
+		}
+		if err := writeImageSearchText(streams.Err, streams.Err, result); err != nil {
 			return err
 		}
 	}
@@ -363,17 +372,36 @@ func countImageFailures(result javdb.ImageSearchResult) int {
 	return failures
 }
 
-// writeImageSearchText 人类可读输出：候选行、相似度、帧、严格匹配详情与逐项错误。
-func writeImageSearchText(w io.Writer, searchResult javdb.ImageSearchResult) error {
+// writeImageSearchRecords 输出非 TTY 可消费的成功影片番号，一行一个记录。
+func writeImageSearchRecords(w io.Writer, searchResult javdb.ImageSearchResult) error {
+	for index, match := range searchResult.Matches {
+		if match.Error != nil {
+			continue
+		}
+		ref := match.Candidate.VideoCode
+		if ref == "" {
+			return fmt.Errorf("reverse search match %d has no video code", index+1)
+		}
+		if _, err := fmt.Fprintln(w, ref); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeImageSearchText 输出人类诊断：候选行、相似度、帧、严格匹配详情与逐项错误。
+// infoW 用于成功候选的诊断，errW 专用于失败项；调用方可将二者都指向 stderr
+// 以保持非 TTY stdout 的机器记录契约。
+func writeImageSearchText(infoW, errW io.Writer, searchResult javdb.ImageSearchResult) error {
 	for index, match := range searchResult.Matches {
 		candidate := match.Candidate
 		if match.Error != nil {
-			if _, err := fmt.Fprintf(w, "%d. %s (%.1f%%)  [失败: %s]\n", index+1, candidate.VideoCode, candidate.Similarity, match.Error.Message); err != nil {
+			if _, err := fmt.Fprintf(errW, "%d. %s (%.1f%%)  [失败: %s]\n", index+1, candidate.VideoCode, candidate.Similarity, match.Error.Message); err != nil {
 				return err
 			}
 			continue
 		}
-		if _, err := fmt.Fprintf(w, "%d. %s (%.1f%%)\n", index+1, candidate.VideoCode, candidate.Similarity); err != nil {
+		if _, err := fmt.Fprintf(infoW, "%d. %s (%.1f%%)\n", index+1, candidate.VideoCode, candidate.Similarity); err != nil {
 			return err
 		}
 		for _, frame := range candidate.Frames {
@@ -381,21 +409,21 @@ func writeImageSearchText(w io.Writer, searchResult javdb.ImageSearchResult) err
 			if frame.ThumbnailURL != "" {
 				line += "  " + frame.ThumbnailURL
 			}
-			if _, err := fmt.Fprintln(w, line); err != nil {
+			if _, err := fmt.Fprintln(infoW, line); err != nil {
 				return err
 			}
 		}
 		if match.Movie != nil {
 			rows := result.ProjectMovies([]map[string]any{match.Movie})
 			for _, row := range rows {
-				if _, err := fmt.Fprintf(w, "   => %s\n", row.Line()); err != nil {
+				if _, err := fmt.Fprintf(infoW, "   => %s\n", row.Line()); err != nil {
 					return err
 				}
 			}
 		}
 	}
 	if len(searchResult.Matches) == 0 {
-		_, err := fmt.Fprintln(w, "(无候选)")
+		_, err := fmt.Fprintln(infoW, "(无候选)")
 		return err
 	}
 	return nil

--- a/internal/cli/commands/search/search.go
+++ b/internal/cli/commands/search/search.go
@@ -559,11 +559,14 @@ func runSearchMagnets(options *invocation.RootOptions, streams *invocation.Strea
 				"magnets": r.magnets,
 			}
 			if r.err != nil {
+				failures++
 				entry["error"] = r.err.Error()
 			}
 			moviesOut = append(moviesOut, entry)
 		}
-		return writeJSON(streams.Out, map[string]any{"movies": moviesOut})
+		if err := writeJSON(streams.Out, map[string]any{"movies": moviesOut}); err != nil {
+			return err
+		}
 	case pipeline.OutputNDJSON:
 		writer := pipeline.NewWriter(streams.Out, pipeline.OutputNDJSON)
 		for _, r := range results {
@@ -677,11 +680,14 @@ func runImageSearchMagnets(options *invocation.RootOptions, streams *invocation.
 				"magnets":    r.magnets,
 			}
 			if r.err != nil {
+				failures++
 				entry["error"] = r.err.Error()
 			}
 			matchesOut = append(matchesOut, entry)
 		}
-		return writeJSON(streams.Out, map[string]any{"reverse_search": result.ReverseSearch, "matches": matchesOut})
+		if err := writeJSON(streams.Out, map[string]any{"reverse_search": result.ReverseSearch, "matches": matchesOut}); err != nil {
+			return err
+		}
 	case pipeline.OutputNDJSON:
 		writer := pipeline.NewWriter(streams.Out, pipeline.OutputNDJSON)
 		for _, r := range results {

--- a/internal/cli/commands/search/search.go
+++ b/internal/cli/commands/search/search.go
@@ -10,10 +10,12 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sync"
 
 	"github.com/spf13/cobra"
 
 	"github.com/FlanChanXwO/javdb-cli/internal/cli/client"
+	magnetspkg "github.com/FlanChanXwO/javdb-cli/internal/cli/commands/magnets"
 	"github.com/FlanChanXwO/javdb-cli/internal/cli/invocation"
 	"github.com/FlanChanXwO/javdb-cli/internal/cli/pipeline"
 	"github.com/FlanChanXwO/javdb-cli/internal/cli/result"
@@ -34,6 +36,9 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 		asImage       bool
 		source        string
 		noCache       bool
+		magnets       int
+		cnsub, hd     bool
+		minSize       string
 	)
 	cmd := &cobra.Command{
 		Use:   "search KEYWORD|IMAGE",
@@ -43,6 +48,15 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 			mode, err := pipeline.ResolveOutputMode(asNDJSON, asJSON, streams.OutIsTerminal)
 			if err != nil {
 				return err
+			}
+			// --magnets 仅支持 movie 搜索。
+			if magnets > 0 || cmd.Flags().Changed("magnets") {
+				if typ != "" && typ != "movie" {
+					return fmt.Errorf("--magnets is only supported for movie search (got --type %q)", typ)
+				}
+				if !cmd.Flags().Changed("cnsub") && !cmd.Flags().Changed("hd") && !cmd.Flags().Changed("min-size") && magnets == 0 {
+					// --magnets 0 不配合筛选 flag 时仍允许（返回全部磁力）。
+				}
 			}
 			reader := bufio.NewReader(streams.In)
 			arg := ""
@@ -54,10 +68,16 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 				return err
 			}
 			if imageMode {
+				if cmd.Flags().Changed("magnets") {
+					return runImageSearchMagnets(options, streams, arg, reader, source, noCache, mode, magnets, cnsub, hd, minSize)
+				}
 				return runImageSearch(options, streams, arg, reader, source, noCache, mode)
 			}
 			if len(inputs) == 0 {
 				return fmt.Errorf("keyword or an image")
+			}
+			if cmd.Flags().Changed("magnets") {
+				return runSearchMagnets(options, streams, inputs, mode, page, limit, zone, sort, filterBy, hasMagnets, magnets, cnsub, hd, minSize)
 			}
 			runner := &pipeline.BatchRunner{
 				Name:       "search",
@@ -91,6 +111,10 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 	cmd.Flags().BoolVar(&asImage, "image", false, "Treat the argument as an image path or HTTP(S) URL")
 	cmd.Flags().StringVar(&source, "source", "", "Reverse-search source (default: reverse_search.default_source)")
 	cmd.Flags().BoolVar(&noCache, "no-cache", false, "Bypass the reverse-search response cache")
+	cmd.Flags().IntVar(&magnets, "magnets", 0, "Fetch magnets for each result: 0=all, N=top N by best rule")
+	cmd.Flags().BoolVar(&cnsub, "cnsub", false, "Only magnets with Chinese subtitles (requires --magnets)")
+	cmd.Flags().BoolVar(&hd, "hd", false, "Only HD magnets (requires --magnets)")
+	cmd.Flags().StringVar(&minSize, "min-size", "", "Min magnet size e.g. 2000, 4GB, 500MB (requires --magnets)")
 	return cmd
 }
 
@@ -433,4 +457,241 @@ func writeJSON(w io.Writer, value any) error {
 	}
 	_, err = w.Write(b)
 	return err
+}
+
+// runSearchMagnets 执行关键词搜索并对每部影片获取磁力：筛选 → 排序 → 截取 N。
+// 结果按搜索结果顺序（影片）和磁力排序顺序输出。
+func runSearchMagnets(options *invocation.RootOptions, streams *invocation.Streams, inputs []pipeline.Envelope, mode pipeline.OutputMode, page, limit int, zone, sort, filterBy string, hasMagnets bool, magnetsCount int, cnsub, hd bool, minSize string) error {
+	c, err := client.New(options, "")
+	if err != nil {
+		return err
+	}
+	minMiB := 0
+	if minSize != "" {
+		minMiB, err = magnetspkg.ParseSizeMiB(minSize)
+		if err != nil {
+			return err
+		}
+	}
+
+	// 收集所有搜索结果影片（保留输入顺序）。
+	var allMovies []map[string]any
+	for _, input := range inputs {
+		keyword := pipeline.ConsumerRef(input)
+		opt := javdb.SearchOptions{
+			Page: page, Limit: limit, Zone: zone, Sort: sort, FilterBy: filterBy, Type: "movie",
+		}
+		res, err := c.Search(context.Background(), keyword, opt)
+		if err != nil {
+			return fmt.Errorf("search failed: %w", err)
+		}
+		movies := res.Movies()
+		if hasMagnets {
+			movies = result.FilterMoviesWithMagnets(movies)
+		}
+		allMovies = append(allMovies, movies...)
+	}
+
+	// 并发获取每部影片的磁力。
+	type magnetResult struct {
+		movie   map[string]any
+		magnets []map[string]any
+		err     error
+	}
+	results := make([]magnetResult, len(allMovies))
+	var wait sync.WaitGroup
+	for i := range allMovies {
+		wait.Add(1)
+		go func(i int) {
+			defer wait.Done()
+			mid := fmt.Sprint(allMovies[i]["id"])
+			mags, err := c.MovieMagnets(context.Background(), mid)
+			if err != nil {
+				results[i] = magnetResult{movie: allMovies[i], err: err}
+				return
+			}
+			mags = javdb.FilterMagnets(mags, cnsub, hd, minMiB)
+			mags = javdb.RankMagnets(mags, magnetsCount)
+			results[i] = magnetResult{movie: allMovies[i], magnets: mags}
+		}(i)
+	}
+	wait.Wait()
+
+	// 输出。
+	failures := 0
+	switch mode {
+	case pipeline.OutputJSON:
+		moviesOut := make([]map[string]any, 0, len(results))
+		for _, r := range results {
+			entry := map[string]any{
+				"number":  r.movie["number"],
+				"id":      r.movie["id"],
+				"magnets": r.magnets,
+			}
+			if r.err != nil {
+				entry["error"] = r.err.Error()
+			}
+			moviesOut = append(moviesOut, entry)
+		}
+		return writeJSON(streams.Out, map[string]any{"movies": moviesOut})
+	case pipeline.OutputNDJSON:
+		writer := pipeline.NewWriter(streams.Out, pipeline.OutputNDJSON)
+		for _, r := range results {
+			ref := fmt.Sprint(r.movie["number"])
+			id := fmt.Sprint(r.movie["id"])
+			if r.err != nil {
+				if err := writer.Write(pipeline.ErrorEnvelope(pipeline.New(pipeline.KindMagnet, ref, id), "search", "magnets", "fetch", r.err.Error())); err != nil {
+					return err
+				}
+				failures++
+				continue
+			}
+			envelope := pipeline.New(pipeline.KindMagnet, ref, id).
+				WithData(map[string]any{"movie": r.movie, "magnets": r.magnets})
+			if err := writer.Write(envelope); err != nil {
+				return err
+			}
+		}
+	default:
+		// 文本/人类模式：逐磁力 URI 输出，失败项写 stderr。
+		for _, r := range results {
+			if r.err != nil {
+				failures++
+				fmt.Fprintf(streams.Err, "search: %s\n", r.err.Error())
+				continue
+			}
+			for _, m := range r.magnets {
+				uri := javdb.MagnetURI(m)
+				if uri != "" {
+					fmt.Fprintln(streams.Out, uri)
+				}
+			}
+		}
+	}
+	if failures > 0 {
+		return fmt.Errorf("search --magnets completed with %d of %d movies failed", failures, len(results))
+	}
+	return nil
+}
+
+// runImageSearchMagnets 执行以图搜番并直接获取磁力：使用 SkipMovieDetail 跳过
+// 完整详情，仅做番号→ID→磁力。结果按 provider 候选顺序输出。
+func runImageSearchMagnets(options *invocation.RootOptions, streams *invocation.Streams, arg string, reader *bufio.Reader, source string, noCache bool, mode pipeline.OutputMode, magnetsCount int, cnsub, hd bool, minSize string) error {
+	setup, err := client.NewReverseSearchClient(options, "", source)
+	if err != nil {
+		return err
+	}
+	imageBytes, err := readInputImage(arg, reader, setup.HTTPClient)
+	if err != nil {
+		return err
+	}
+	result, err := setup.Client.SearchByImage(context.Background(), javdb.ReverseSearchRequest{
+		Image:       imageBytes.Bytes,
+		Filename:    imageBytes.Filename,
+		Source:      setup.Source,
+		BypassCache: noCache,
+	}, javdb.ImageSearchOptions{SkipMovieDetail: true})
+	if err != nil {
+		return fmt.Errorf("reverse search failed: %w", err)
+	}
+
+	minMiB := 0
+	if minSize != "" {
+		minMiB, err = magnetspkg.ParseSizeMiB(minSize)
+		if err != nil {
+			return err
+		}
+	}
+
+	// 并发获取每个候选的磁力。
+	type magnetResult struct {
+		match   javdb.ImageSearchMatch
+		magnets []map[string]any
+		err     error
+	}
+	results := make([]magnetResult, len(result.Matches))
+	var wait sync.WaitGroup
+	for i := range result.Matches {
+		wait.Add(1)
+		go func(i int) {
+			defer wait.Done()
+			match := result.Matches[i]
+			if match.Error != nil {
+				results[i] = magnetResult{match: match, err: fmt.Errorf("%s", match.Error.Message)}
+				return
+			}
+			if match.MovieID == "" {
+				results[i] = magnetResult{match: match, err: fmt.Errorf("no movie id")}
+				return
+			}
+			mags, err := setup.Client.MovieMagnets(context.Background(), match.MovieID)
+			if err != nil {
+				results[i] = magnetResult{match: match, err: err}
+				return
+			}
+			mags = javdb.FilterMagnets(mags, cnsub, hd, minMiB)
+			mags = javdb.RankMagnets(mags, magnetsCount)
+			results[i] = magnetResult{match: match, magnets: mags}
+		}(i)
+	}
+	wait.Wait()
+
+	failures := 0
+	switch mode {
+	case pipeline.OutputJSON:
+		matchesOut := make([]map[string]any, 0, len(results))
+		for _, r := range results {
+			entry := map[string]any{
+				"video_code": r.match.Candidate.VideoCode,
+				"movie_id":   r.match.MovieID,
+				"magnets":    r.magnets,
+			}
+			if r.err != nil {
+				entry["error"] = r.err.Error()
+			}
+			matchesOut = append(matchesOut, entry)
+		}
+		return writeJSON(streams.Out, map[string]any{"reverse_search": result.ReverseSearch, "matches": matchesOut})
+	case pipeline.OutputNDJSON:
+		writer := pipeline.NewWriter(streams.Out, pipeline.OutputNDJSON)
+		for _, r := range results {
+			ref := r.match.Candidate.VideoCode
+			id := r.match.MovieID
+			if r.err != nil {
+				if err := writer.Write(pipeline.ErrorEnvelope(pipeline.New(pipeline.KindMagnet, ref, id), "search", "magnets", "fetch", r.err.Error())); err != nil {
+					return err
+				}
+				failures++
+				continue
+			}
+			envelope := pipeline.New(pipeline.KindMagnet, ref, id).
+				WithData(map[string]any{
+					"movie":      map[string]any{"id": r.match.MovieID},
+					"magnets":    r.magnets,
+					"similarity": r.match.Candidate.Similarity,
+				}).
+				WithMeta(map[string]any{"reverse_search": map[string]any{"source": result.ReverseSearch.Source, "candidates": result.ReverseSearch.Candidates}})
+			if err := writer.Write(envelope); err != nil {
+				return err
+			}
+		}
+	default:
+		for _, r := range results {
+			if r.err != nil {
+				failures++
+				fmt.Fprintf(streams.Err, "search: %s\n", r.err.Error())
+				continue
+			}
+			for _, m := range r.magnets {
+				uri := javdb.MagnetURI(m)
+				if uri != "" {
+					fmt.Fprintln(streams.Out, uri)
+				}
+			}
+		}
+	}
+	if failures > 0 {
+		return fmt.Errorf("search --magnets completed with %d of %d candidates failed", failures, len(results))
+	}
+	return nil
 }

--- a/internal/cli/commands/search/search.go
+++ b/internal/cli/commands/search/search.go
@@ -82,7 +82,9 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 			runner := &pipeline.BatchRunner{
 				Name:       "search",
 				LegacyJSON: true,
-				Kinds:      []pipeline.Kind{pipeline.KindMovie},
+				// 非 TTY 单项也输出可供下游消费的稳定番号记录。
+				RouteTextThroughPipeline: true,
+				Kinds:                    []pipeline.Kind{pipeline.KindMovie},
 				ClientFactory: func() (*javdb.Client, error) {
 					return client.New(options, "")
 				},

--- a/internal/cli/commands/search/search.go
+++ b/internal/cli/commands/search/search.go
@@ -40,7 +40,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 		Short: "Search movies (or other dimensions with --type)",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			mode, err := pipeline.ResolveOutputMode(asNDJSON, asJSON)
+			mode, err := pipeline.ResolveOutputMode(asNDJSON, asJSON, streams.OutIsTerminal)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/commands/search/search.go
+++ b/internal/cli/commands/search/search.go
@@ -594,13 +594,17 @@ func runSearchMagnets(options *invocation.RootOptions, streams *invocation.Strea
 		for _, r := range results {
 			if r.err != nil {
 				failures++
-				fmt.Fprintf(streams.Err, "search: %s\n", r.err.Error())
+				if _, err := fmt.Fprintf(streams.Err, "search: %s\n", r.err.Error()); err != nil {
+					return err
+				}
 				continue
 			}
 			for _, m := range r.magnets {
 				uri := javdb.MagnetURI(m)
 				if uri != "" {
-					fmt.Fprintln(streams.Out, uri)
+					if _, err := fmt.Fprintln(streams.Out, uri); err != nil {
+						return err
+					}
 				}
 			}
 		}
@@ -719,13 +723,17 @@ func runImageSearchMagnets(options *invocation.RootOptions, streams *invocation.
 		for _, r := range results {
 			if r.err != nil {
 				failures++
-				fmt.Fprintf(streams.Err, "search: %s\n", r.err.Error())
+				if _, err := fmt.Fprintf(streams.Err, "search: %s\n", r.err.Error()); err != nil {
+					return err
+				}
 				continue
 			}
 			for _, m := range r.magnets {
 				uri := javdb.MagnetURI(m)
 				if uri != "" {
-					fmt.Fprintln(streams.Out, uri)
+					if _, err := fmt.Fprintln(streams.Out, uri); err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/internal/cli/commands/search/search.go
+++ b/internal/cli/commands/search/search.go
@@ -74,7 +74,7 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 			}
 			if imageMode {
 				if cmd.Flags().Changed("magnets") {
-					return runImageSearchMagnets(options, streams, arg, reader, source, noCache, mode, magnets, cnsub, hd, minSize)
+					return runImageSearchMagnets(cmd.Context(), options, streams, arg, reader, source, noCache, mode, magnets, cnsub, hd, minSize)
 				}
 				return runImageSearch(options, streams, arg, reader, source, noCache, mode)
 			}
@@ -82,10 +82,11 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 				return fmt.Errorf("keyword or an image")
 			}
 			if cmd.Flags().Changed("magnets") {
-				return runSearchMagnets(options, streams, inputs, mode, page, limit, zone, sort, filterBy, hasMagnets, magnets, cnsub, hd, minSize)
+				return runSearchMagnets(cmd.Context(), options, streams, inputs, mode, page, limit, zone, sort, filterBy, hasMagnets, magnets, cnsub, hd, minSize)
 			}
 			runner := &pipeline.BatchRunner{
 				Name:       "search",
+				Context:    cmd.Context(),
 				LegacyJSON: true,
 				// 非 TTY 单项也输出可供下游消费的稳定番号记录。
 				RouteTextThroughPipeline: true,
@@ -510,7 +511,7 @@ func writeJSON(w io.Writer, value any) error {
 
 // runSearchMagnets 执行关键词搜索并对每部影片获取磁力：筛选 → 排序 → 截取 N。
 // 结果按搜索结果顺序（影片）和磁力排序顺序输出。
-func runSearchMagnets(options *invocation.RootOptions, streams *invocation.Streams, inputs []pipeline.Envelope, mode pipeline.OutputMode, page, limit int, zone, sort, filterBy string, hasMagnets bool, magnetsCount int, cnsub, hd bool, minSize string) error {
+func runSearchMagnets(ctx context.Context, options *invocation.RootOptions, streams *invocation.Streams, inputs []pipeline.Envelope, mode pipeline.OutputMode, page, limit int, zone, sort, filterBy string, hasMagnets bool, magnetsCount int, cnsub, hd bool, minSize string) error {
 	c, err := client.New(options, "")
 	if err != nil {
 		return err
@@ -553,7 +554,7 @@ func runSearchMagnets(options *invocation.RootOptions, streams *invocation.Strea
 		opt := javdb.SearchOptions{
 			Page: page, Limit: limit, Zone: zone, Sort: sort, FilterBy: filterBy, Type: "movie",
 		}
-		res, err := c.Search(context.Background(), keyword, opt)
+		res, err := c.Search(ctx, keyword, opt)
 		if err != nil {
 			itemErr := fmt.Errorf("search failed: %w", err)
 			results = append(results, magnetResult{
@@ -571,29 +572,46 @@ func runSearchMagnets(options *invocation.RootOptions, streams *invocation.Strea
 		}
 	}
 
-	// 并发获取每部影片的磁力。
+	// 使用有界 worker 池获取磁力，避免结果量放大为无界 API 并发；索引写入
+	// 保留搜索结果顺序，ctx 取消时不再领取新任务。
+	const workers = 4
+	jobs := make(chan int)
 	var wait sync.WaitGroup
-	for i := range results {
-		if results[i].err != nil {
-			continue
-		}
+	for worker := 0; worker < workers; worker++ {
 		wait.Add(1)
-		go func(i int) {
+		go func() {
 			defer wait.Done()
-			mid := fmt.Sprint(results[i].movie["id"])
-			mags, err := c.MovieMagnets(context.Background(), mid)
-			if err != nil {
-				results[i].err = err
-				results[i].errorEnvelope = pipeline.ErrorEnvelope(
-					pipeline.New(pipeline.KindMagnet, fmt.Sprint(results[i].movie["number"]), mid),
-					"search", "magnets", "fetch", err.Error(),
-				)
-				return
+			for i := range jobs {
+				if results[i].err != nil {
+					continue
+				}
+				mid := fmt.Sprint(results[i].movie["id"])
+				mags, err := c.MovieMagnets(ctx, mid)
+				if err != nil {
+					results[i].err = err
+					results[i].errorEnvelope = pipeline.ErrorEnvelope(
+						pipeline.New(pipeline.KindMagnet, fmt.Sprint(results[i].movie["number"]), mid),
+						"search", "magnets", "fetch", err.Error(),
+					)
+					return
+				}
+				mags = javdb.FilterMagnets(mags, cnsub, hd, minMiB)
+				results[i].magnets = javdb.RankMagnets(mags, magnetsCount)
 			}
-			mags = javdb.FilterMagnets(mags, cnsub, hd, minMiB)
-			results[i].magnets = javdb.RankMagnets(mags, magnetsCount)
-		}(i)
+		}()
 	}
+	for i := range results {
+		if results[i].err == nil {
+			select {
+			case jobs <- i:
+			case <-ctx.Done():
+				close(jobs)
+				wait.Wait()
+				return ctx.Err()
+			}
+		}
+	}
+	close(jobs)
 	wait.Wait()
 
 	// 输出。
@@ -681,7 +699,7 @@ func pipelineErrorMessage(envelope pipeline.Envelope) string {
 
 // runImageSearchMagnets 执行以图搜番并直接获取磁力：使用 SkipMovieDetail 跳过
 // 完整详情，仅做番号→ID→磁力。结果按 provider 候选顺序输出。
-func runImageSearchMagnets(options *invocation.RootOptions, streams *invocation.Streams, arg string, reader *bufio.Reader, source string, noCache bool, mode pipeline.OutputMode, magnetsCount int, cnsub, hd bool, minSize string) error {
+func runImageSearchMagnets(ctx context.Context, options *invocation.RootOptions, streams *invocation.Streams, arg string, reader *bufio.Reader, source string, noCache bool, mode pipeline.OutputMode, magnetsCount int, cnsub, hd bool, minSize string) error {
 	setup, err := client.NewReverseSearchClient(options, "", source)
 	if err != nil {
 		return err
@@ -690,7 +708,7 @@ func runImageSearchMagnets(options *invocation.RootOptions, streams *invocation.
 	if err != nil {
 		return err
 	}
-	result, err := setup.Client.SearchByImage(context.Background(), javdb.ReverseSearchRequest{
+	result, err := setup.Client.SearchByImage(ctx, javdb.ReverseSearchRequest{
 		Image:       imageBytes.Bytes,
 		Filename:    imageBytes.Filename,
 		Source:      setup.Source,
@@ -708,37 +726,51 @@ func runImageSearchMagnets(options *invocation.RootOptions, streams *invocation.
 		}
 	}
 
-	// 并发获取每个候选的磁力。
+	// 使用有界 worker 池获取每个候选的磁力，并按候选索引保序。
 	type magnetResult struct {
 		match   javdb.ImageSearchMatch
 		magnets []map[string]any
 		err     error
 	}
 	results := make([]magnetResult, len(result.Matches))
+	const workers = 4
+	jobs := make(chan int)
 	var wait sync.WaitGroup
-	for i := range result.Matches {
+	for worker := 0; worker < workers; worker++ {
 		wait.Add(1)
-		go func(i int) {
+		go func() {
 			defer wait.Done()
-			match := result.Matches[i]
-			if match.Error != nil {
-				results[i] = magnetResult{match: match, err: fmt.Errorf("%s", match.Error.Message)}
-				return
+			for i := range jobs {
+				match := result.Matches[i]
+				if match.Error != nil {
+					results[i] = magnetResult{match: match, err: fmt.Errorf("%s", match.Error.Message)}
+					return
+				}
+				if match.MovieID == "" {
+					results[i] = magnetResult{match: match, err: fmt.Errorf("no movie id")}
+					return
+				}
+				mags, err := setup.Client.MovieMagnets(ctx, match.MovieID)
+				if err != nil {
+					results[i] = magnetResult{match: match, err: err}
+					return
+				}
+				mags = javdb.FilterMagnets(mags, cnsub, hd, minMiB)
+				mags = javdb.RankMagnets(mags, magnetsCount)
+				results[i] = magnetResult{match: match, magnets: mags}
 			}
-			if match.MovieID == "" {
-				results[i] = magnetResult{match: match, err: fmt.Errorf("no movie id")}
-				return
-			}
-			mags, err := setup.Client.MovieMagnets(context.Background(), match.MovieID)
-			if err != nil {
-				results[i] = magnetResult{match: match, err: err}
-				return
-			}
-			mags = javdb.FilterMagnets(mags, cnsub, hd, minMiB)
-			mags = javdb.RankMagnets(mags, magnetsCount)
-			results[i] = magnetResult{match: match, magnets: mags}
-		}(i)
+		}()
 	}
+	for i := range result.Matches {
+		select {
+		case jobs <- i:
+		case <-ctx.Done():
+			close(jobs)
+			wait.Wait()
+			return ctx.Err()
+		}
+	}
+	close(jobs)
 	wait.Wait()
 
 	failures := 0

--- a/internal/cli/commands/search/search.go
+++ b/internal/cli/commands/search/search.go
@@ -69,6 +69,9 @@ func New(options *invocation.RootOptions, streams *invocation.Streams) *cobra.Co
 				RunOne: func(c *javdb.Client, ctx context.Context, input pipeline.Envelope) (pipeline.Envelope, error) {
 					return runSearchOne(c, ctx, input, page, limit, zone, sort, filterBy, typ, hasMagnets)
 				},
+				RunMany: func(c *javdb.Client, ctx context.Context, input pipeline.Envelope) ([]pipeline.Envelope, error) {
+					return runSearchMany(c, ctx, input, page, limit, zone, sort, filterBy, typ, hasMagnets)
+				},
 				Legacy: func(args []string) error {
 					return runTextSearch(options, streams, args[0], page, limit, zone, sort, filterBy, typ, hasMagnets, asJSON)
 				},
@@ -182,7 +185,44 @@ func runSearchOne(c *javdb.Client, ctx context.Context, input pipeline.Envelope,
 	return envelope, nil
 }
 
-// runTextSearch 保持既有文本搜索行为。
+// runSearchMany 执行单个关键词搜索并返回多个信封（fan-out）：
+//   - movie 类型：每部影片一个 KindMovie 信封，ref 为番号，id 为内部 ID。
+//   - 其他 --type：回退为单信封（与 runSearchOne 相同）。
+func runSearchMany(c *javdb.Client, ctx context.Context, input pipeline.Envelope, page, limit int, zone, sort, filterBy, typ string, hasMagnets bool) ([]pipeline.Envelope, error) {
+	keyword := pipeline.ConsumerRef(input)
+	opt := javdb.SearchOptions{
+		Page:     page,
+		Limit:    limit,
+		Zone:     zone,
+		Sort:     sort,
+		FilterBy: filterBy,
+		Type:     typ,
+	}
+	res, err := c.Search(ctx, keyword, opt)
+	if err != nil {
+		return nil, fmt.Errorf("search failed: %w", err)
+	}
+	if typ == "" || typ == "movie" {
+		movies := res.Movies()
+		if hasMagnets {
+			movies = result.FilterMoviesWithMagnets(movies)
+		}
+		envelopes := make([]pipeline.Envelope, 0, len(movies))
+		for _, m := range movies {
+			ref := fmt.Sprint(m["number"])
+			id := fmt.Sprint(m["id"])
+			envelope := pipeline.New(pipeline.KindMovie, ref, id).WithData(map[string]any{"movie": m})
+			envelopes = append(envelopes, envelope)
+		}
+		return envelopes, nil
+	}
+	// 非 movie 类型回退为单信封。
+	one, err := runSearchOne(c, ctx, input, page, limit, zone, sort, filterBy, typ, hasMagnets)
+	if err != nil {
+		return nil, err
+	}
+	return []pipeline.Envelope{one}, nil
+}
 func runTextSearch(options *invocation.RootOptions, streams *invocation.Streams, keyword string, page, limit int, zone, sort, filterBy, typ string, hasMagnets, asJSON bool) error {
 	c, err := client.New(options, "")
 	if err != nil {

--- a/internal/cli/commands/search/search_image_test.go
+++ b/internal/cli/commands/search/search_image_test.go
@@ -83,6 +83,7 @@ func TestSearchImagePathAutoDetectsAndOutputsMatches(t *testing.T) {
 
 	streams := invocation.NewStreams(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
 	streams.InIsTerminal = true
+	streams.OutIsTerminal = true
 	err := executeSearch(t, streams, &invocation.RootOptions{Host: javdbServer.URL},
 		imagePath, "--source", "test", "--no-cache")
 	// 部分失败（GHOST-999 无法解析）必须在输出完成后非零。
@@ -99,8 +100,9 @@ func TestSearchImagePathAutoDetectsAndOutputsMatches(t *testing.T) {
 	if !strings.Contains(out, "9DGB5X") {
 		t.Errorf("output lacks matched movie projection:\n%s", out)
 	}
-	if !strings.Contains(out, "GHOST-999") || !strings.Contains(out, "失败") {
-		t.Errorf("output lacks per-item failure:\n%s", out)
+	errOut := streams.Err.(*bytes.Buffer).String()
+	if !strings.Contains(errOut, "GHOST-999") || !strings.Contains(errOut, "失败") {
+		t.Errorf("stderr lacks per-item failure:\n%s", errOut)
 	}
 	if !strings.Contains(err.Error(), "1 of 2 candidates failed") {
 		t.Errorf("error should count failures: %v", err)
@@ -150,12 +152,13 @@ func TestSearchImageFromStdinMagicDefaultsToText(t *testing.T) {
 		t.Fatal("partial failure must exit non-zero")
 	}
 	out := streams.Out.(*bytes.Buffer).String()
-	// 管道只负责输入分类，未显式指定结构化输出时仍使用纯文本。
-	if !strings.Contains(out, "SSIS-589") || !strings.Contains(out, "95.2%") {
-		t.Errorf("stdin image text output lacks candidate:\n%s", out)
+	// 非 TTY 纯文本 stdout 只保留成功番号，供 magnets 消费。
+	if out != "SSIS-589\n" {
+		t.Errorf("stdin image text output = %q, want stable movie ref", out)
 	}
-	if !strings.Contains(out, "GHOST-999") || !strings.Contains(out, "失败") {
-		t.Errorf("stdin image text output lacks failure:\n%s", out)
+	errOut := streams.Err.(*bytes.Buffer).String()
+	if !strings.Contains(errOut, "SSIS-589") || !strings.Contains(errOut, "01:04:53") || !strings.Contains(errOut, "GHOST-999") || !strings.Contains(errOut, "失败") {
+		t.Errorf("stdin image stderr lacks diagnostics:\n%s", errOut)
 	}
 	if strings.Contains(out, `"kind":`) {
 		t.Errorf("stdin image unexpectedly emitted NDJSON without --ndjson:\n%s", out)
@@ -233,7 +236,7 @@ func TestSearchImageURLGoesThroughProxy(t *testing.T) {
 	if !proxySawRequest.Load() {
 		t.Fatal("image URL request did not go through the configured proxy")
 	}
-	if !strings.Contains(streams.Out.(*bytes.Buffer).String(), "SSIS-589") {
-		t.Errorf("proxy image result missing candidate")
+	if !strings.Contains(streams.Out.(*bytes.Buffer).String(), "SSIS-589") && !strings.Contains(streams.Err.(*bytes.Buffer).String(), "SSIS-589") {
+		t.Errorf("proxy image result missing candidate: stdout=%q stderr=%q", streams.Out.(*bytes.Buffer).String(), streams.Err.(*bytes.Buffer).String())
 	}
 }

--- a/internal/cli/commands/search/search_image_test.go
+++ b/internal/cli/commands/search/search_image_test.go
@@ -165,6 +165,112 @@ func TestSearchImageFromStdinMagicDefaultsToText(t *testing.T) {
 	}
 }
 
+// TestSearchImageTextSkipsMovieDetail 验证非 TTY 稳定 ref 路径只解析影片 ID，
+// 不为成功候选追加 MovieDetail 请求。
+func TestSearchImageTextSkipsMovieDetail(t *testing.T) {
+	provider := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = writer.Write([]byte(`{"results":[{"video_code":"SSIS-589","best_similarity":95.2,"frames":[]}]}`))
+	}))
+	defer provider.Close()
+	var detailRequests atomic.Int64
+	javdbServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.URL.Path == "/api/v2/search":
+			_, _ = writer.Write([]byte(`{"success":true,"data":{"movies":[{"number":"SSIS-589","id":"9DGB5X"}]}}`))
+		case strings.HasPrefix(request.URL.Path, "/api/v4/movies/9DGB5X"):
+			detailRequests.Add(1)
+			_, _ = writer.Write([]byte(`{"success":true,"data":{"movie":{"id":"9DGB5X","number":"SSIS-589"}}}`))
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer javdbServer.Close()
+	writeReverseSearchConfig(t, provider.URL)
+
+	streams := invocation.NewStreams(bytes.NewReader(testJPEG), &bytes.Buffer{}, &bytes.Buffer{})
+	if err := executeSearch(t, streams, &invocation.RootOptions{Host: javdbServer.URL}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got := streams.Out.(*bytes.Buffer).String(); got != "SSIS-589\n" {
+		t.Fatalf("text output = %q", got)
+	}
+	if detailRequests.Load() != 0 {
+		t.Fatalf("MovieDetail requests = %d, want 0", detailRequests.Load())
+	}
+}
+
+// TestSearchImageMagnetsEndToEnd 覆盖 provider → 严格 ID 解析 → 磁力请求，
+// 并锁定 text、NDJSON、JSON 三种输出；该快路径不得请求 MovieDetail。
+func TestSearchImageMagnetsEndToEnd(t *testing.T) {
+	provider := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = writer.Write([]byte(`{"results":[{"video_code":"SSIS-589","best_similarity":95.2,"frames":[]}]}`))
+	}))
+	defer provider.Close()
+	var detailRequests atomic.Int64
+	javdbServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.URL.Path == "/api/v2/search":
+			_, _ = writer.Write([]byte(`{"success":true,"data":{"movies":[{"number":"SSIS-589","id":"9DGB5X"}]}}`))
+		case request.URL.Path == "/api/v1/movies/9DGB5X/magnets":
+			_, _ = writer.Write([]byte(`{"success":true,"data":{"magnets":[{"name":"HD","hash":"AAA","size":4096,"hd":true}]}}`))
+		case strings.HasPrefix(request.URL.Path, "/api/v4/movies/9DGB5X"):
+			detailRequests.Add(1)
+			http.NotFound(writer, request)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer javdbServer.Close()
+	writeReverseSearchConfig(t, provider.URL)
+
+	for _, tc := range []struct {
+		name string
+		flag string
+	}{
+		{name: "text"},
+		{name: "ndjson", flag: "--ndjson"},
+		{name: "json", flag: "--json"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			streams := invocation.NewStreams(bytes.NewReader(testJPEG), &bytes.Buffer{}, &bytes.Buffer{})
+			args := []string{"--magnets", "1", "--source", "test", "--no-cache"}
+			if tc.flag != "" {
+				args = append(args, tc.flag)
+			}
+			if err := executeSearch(t, streams, &invocation.RootOptions{Host: javdbServer.URL}, args...); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			out := streams.Out.(*bytes.Buffer).String()
+			switch tc.flag {
+			case "--ndjson":
+				var envelope map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &envelope); err != nil {
+					t.Fatal(err)
+				}
+				if envelope["kind"] != "magnet" || envelope["ref"] != "SSIS-589" {
+					t.Fatalf("NDJSON envelope = %v", envelope)
+				}
+			case "--json":
+				var payload map[string]any
+				if err := json.Unmarshal([]byte(out), &payload); err != nil {
+					t.Fatal(err)
+				}
+				matches, _ := payload["matches"].([]any)
+				if len(matches) != 1 {
+					t.Fatalf("JSON matches = %v", payload["matches"])
+				}
+			default:
+				if !strings.Contains(out, "magnet:?xt=urn:btih:AAA") {
+					t.Fatalf("text output = %q", out)
+				}
+			}
+		})
+	}
+	if detailRequests.Load() != 0 {
+		t.Fatalf("MovieDetail requests = %d, want 0", detailRequests.Load())
+	}
+}
+
 func TestSearchAmbiguousArgumentAndStdin(t *testing.T) {
 	// 位置参数（非图片路径）+ 非空 stdin 同时存在 → 歧义错误。
 	streams := invocation.NewStreams(bytes.NewReader(testJPEG), &bytes.Buffer{}, &bytes.Buffer{})

--- a/internal/cli/commands/search/search_pipeline_test.go
+++ b/internal/cli/commands/search/search_pipeline_test.go
@@ -105,3 +105,75 @@ func TestSearchNDJSONFanOutMultipleMovies(t *testing.T) {
 		}
 	}
 }
+
+// TestSearchMagnetsFlagOutputsMagnetURIs search --magnets 关键词路径：文本模式
+// 输出磁力 URI，NDJSON 输出 kind=magnet 信封。
+func TestSearchMagnetsFlagOutputsMagnetURIs(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	t.Setenv("HOMEDRIVE", filepath.VolumeName(t.TempDir()))
+	t.Setenv("HOMEPATH", strings.TrimPrefix(t.TempDir(), filepath.VolumeName(t.TempDir())))
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v2/search":
+			_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{
+				"movies": []map[string]any{{"number": "SSIS-001", "id": "id-1"}},
+			}})
+		case "/api/v1/movies/id-1/magnets":
+			_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{
+				"magnets": []map[string]any{
+					{"name": "HD", "hash": "AAA", "size": float64(4096), "hd": true},
+					{"name": "SD", "hash": "BBB", "size": float64(64)},
+				},
+			}})
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	// 文本模式：输出磁力 URI。
+	streams := invocation.NewStreams(strings.NewReader("SSIS\n"), &bytes.Buffer{}, &bytes.Buffer{})
+	cmd := New(&invocation.RootOptions{Host: server.URL}, streams)
+	cmd.SetArgs([]string{"--magnets", "1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	out := streams.Out.(*bytes.Buffer).String()
+	if !strings.Contains(out, "magnet:?xt=urn:btih:AAA") {
+		t.Errorf("text output should contain best magnet URI, got %q", out)
+	}
+	if strings.Contains(out, "BBB") {
+		t.Errorf("text output should only contain top 1 magnet (AAA), got %q", out)
+	}
+
+	// NDJSON 模式：输出 kind=magnet 信封。
+	streams2 := invocation.NewStreams(strings.NewReader("SSIS\n"), &bytes.Buffer{}, &bytes.Buffer{})
+	cmd2 := New(&invocation.RootOptions{Host: server.URL}, streams2)
+	cmd2.SetArgs([]string{"--magnets", "0", "--ndjson"})
+	if err := cmd2.Execute(); err != nil {
+		t.Fatalf("execute ndjson: %v", err)
+	}
+	out2 := streams2.Out.(*bytes.Buffer).String()
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out2)), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if envelope["kind"] != "magnet" {
+		t.Errorf("kind = %v, want magnet", envelope["kind"])
+	}
+	if envelope["ref"] != "SSIS-001" {
+		t.Errorf("ref = %v, want SSIS-001", envelope["ref"])
+	}
+}
+
+// TestSearchMagnetsRejectsNonMovieType search --magnets 与非 movie --type 互斥。
+func TestSearchMagnetsRejectsNonMovieType(t *testing.T) {
+	streams := invocation.NewStreams(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	cmd := New(&invocation.RootOptions{}, streams)
+	cmd.SetArgs([]string{"--magnets", "3", "--type", "actor"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "only supported for movie search") {
+		t.Fatalf("expected type mismatch error, got %v", err)
+	}
+}

--- a/internal/cli/commands/search/search_pipeline_test.go
+++ b/internal/cli/commands/search/search_pipeline_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // TestSearchTextStdinBatchConsumesKeywords 文本 stdin 批处理：逐关键词搜索并
-// 默认输出纯文本，顺序保持。
+// 按 fan-out 输出每部影片的番号，顺序保持。
 func TestSearchTextStdinBatchConsumesKeywords(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("USERPROFILE", t.TempDir())
@@ -34,8 +34,9 @@ func TestSearchTextStdinBatchConsumesKeywords(t *testing.T) {
 		t.Fatalf("execute: %v", err)
 	}
 	out := streams.Out.(*bytes.Buffer).String()
-	if out != "ssis-589\nhzgd-246\n" {
-		t.Errorf("default pipeline output = %q, want plain input refs", out)
+	// fan-out 后每部影片输出番号（大写），而非原始关键词。
+	if out != "SSIS-589\nHZGD-246\n" {
+		t.Errorf("fan-out pipeline output = %q, want movie numbers", out)
 	}
 }
 
@@ -60,5 +61,47 @@ func TestSearchNDJSONBatchRejectsWrongKind(t *testing.T) {
 	out := streams.Out.(*bytes.Buffer).String()
 	if !strings.Contains(out, `"kind":"error"`) || !strings.Contains(out, "unsupported kind") {
 		t.Errorf("error envelope missing:\n%s", out)
+	}
+}
+
+// TestSearchNDJSONFanOutMultipleMovies NDJSON 批处理 fan-out：单关键词搜索返回
+// 多部影片，每部输出一个 movie 信封。
+func TestSearchNDJSONFanOutMultipleMovies(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	t.Setenv("HOMEDRIVE", filepath.VolumeName(t.TempDir()))
+	t.Setenv("HOMEPATH", strings.TrimPrefix(t.TempDir(), filepath.VolumeName(t.TempDir())))
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{
+			"movies": []map[string]any{
+				{"number": "SSIS-001", "id": "id-1"},
+				{"number": "SSIS-002", "id": "id-2"},
+			},
+		}})
+	}))
+	defer server.Close()
+
+	streams := invocation.NewStreams(strings.NewReader("SSIS\n"), &bytes.Buffer{}, &bytes.Buffer{})
+	cmd := New(&invocation.RootOptions{Host: server.URL}, streams)
+	cmd.SetArgs([]string{"--ndjson"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	out := streams.Out.(*bytes.Buffer).String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 fan-out envelopes, got %d lines", len(lines))
+	}
+	for i, want := range []string{"SSIS-001", "SSIS-002"} {
+		var envelope map[string]any
+		if err := json.Unmarshal([]byte(lines[i]), &envelope); err != nil {
+			t.Fatal(err)
+		}
+		if envelope["ref"] != want {
+			t.Errorf("line %d ref = %v, want %s", i, envelope["ref"], want)
+		}
+		if envelope["kind"] != "movie" {
+			t.Errorf("line %d kind = %v, want movie", i, envelope["kind"])
+		}
 	}
 }

--- a/internal/cli/commands/search/search_pipeline_test.go
+++ b/internal/cli/commands/search/search_pipeline_test.go
@@ -193,6 +193,53 @@ func TestSearchMagnetsFlagOutputsMagnetURIs(t *testing.T) {
 	}
 }
 
+// TestSearchMagnetsJSONPartialFailureReturnsError 验证 JSON 保留成功/失败明细，
+// 但部分磁力请求失败时命令仍以非零错误结束。
+func TestSearchMagnetsJSONPartialFailureReturnsError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	t.Setenv("HOMEDRIVE", filepath.VolumeName(t.TempDir()))
+	t.Setenv("HOMEPATH", strings.TrimPrefix(t.TempDir(), filepath.VolumeName(t.TempDir())))
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v2/search":
+			_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{
+				"movies": []map[string]any{
+					{"number": "SSIS-001", "id": "id-ok"},
+					{"number": "SSIS-002", "id": "id-fail"},
+				},
+			}})
+		case "/api/v1/movies/id-ok/magnets":
+			_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{
+				"magnets": []map[string]any{{"name": "HD", "hash": "AAA"}},
+			}})
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	streams := invocation.NewStreams(strings.NewReader("SSIS\n"), &bytes.Buffer{}, &bytes.Buffer{})
+	cmd := New(&invocation.RootOptions{Host: server.URL}, streams)
+	cmd.SetArgs([]string{"--magnets", "0", "--json"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "1 of 2 movies failed") {
+		t.Fatalf("error = %v, output = %q, want partial-failure summary", err, streams.Out.(*bytes.Buffer).String())
+	}
+	var output map[string]any
+	if err := json.Unmarshal(streams.Out.(*bytes.Buffer).Bytes(), &output); err != nil {
+		t.Fatalf("JSON output invalid: %v", err)
+	}
+	movies, _ := output["movies"].([]any)
+	if len(movies) != 2 {
+		t.Fatalf("movies = %d, want 2", len(movies))
+	}
+	failed, _ := movies[1].(map[string]any)
+	if failed["error"] == nil || failed["error"] == "" {
+		t.Fatalf("failed movie missing error detail: %v", failed)
+	}
+}
+
 // TestSearchMagnetsRejectsNonMovieType search --magnets 与非 movie --type 互斥。
 func TestSearchMagnetsRejectsNonMovieType(t *testing.T) {
 	streams := invocation.NewStreams(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})

--- a/internal/cli/commands/search/search_pipeline_test.go
+++ b/internal/cli/commands/search/search_pipeline_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	magnetscmd "github.com/FlanChanXwO/javdb-cli/internal/cli/commands/magnets"
 	"github.com/FlanChanXwO/javdb-cli/internal/cli/invocation"
 )
 
@@ -175,5 +176,59 @@ func TestSearchMagnetsRejectsNonMovieType(t *testing.T) {
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "only supported for movie search") {
 		t.Fatalf("expected type mismatch error, got %v", err)
+	}
+}
+
+// TestSearchPipelineToMagnets end-to-end: search --ndjson | magnets --ndjson
+// 验证搜索 fan-out 的 movie 信封（带 id）可被 magnets 消费并输出 magnet 信封。
+func TestSearchPipelineToMagnets(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	t.Setenv("HOMEDRIVE", filepath.VolumeName(t.TempDir()))
+	t.Setenv("HOMEPATH", strings.TrimPrefix(t.TempDir(), filepath.VolumeName(t.TempDir())))
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v2/search":
+			_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{
+				"movies": []map[string]any{{"number": "SSIS-001", "id": "id-1"}},
+			}})
+		case "/api/v4/movies/id-1":
+			_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{"movie": map[string]any{"magnets_count": float64(1)}}})
+		case "/api/v1/movies/id-1/magnets":
+			_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{
+				"magnets": []map[string]any{{"name": "HD", "hash": "AAA", "size": float64(4096), "hd": true}},
+			}})
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	// Step 1: search --ndjson produces movie envelopes with id.
+	searchStreams := invocation.NewStreams(strings.NewReader("SSIS\n"), &bytes.Buffer{}, &bytes.Buffer{})
+	searchCmd := New(&invocation.RootOptions{Host: server.URL}, searchStreams)
+	searchCmd.SetArgs([]string{"--ndjson"})
+	if err := searchCmd.Execute(); err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	searchOutput := searchStreams.Out.(*bytes.Buffer).String()
+
+	// Step 2: magnets --ndjson consumes the search output.
+	magnetsStreams := invocation.NewStreams(strings.NewReader(searchOutput), &bytes.Buffer{}, &bytes.Buffer{})
+	magnetsCmd := magnetscmd.New(&invocation.RootOptions{Host: server.URL}, magnetsStreams)
+	magnetsCmd.SetArgs([]string{"--ndjson"})
+	if err := magnetsCmd.Execute(); err != nil {
+		t.Fatalf("magnets: %v", err)
+	}
+	magnetsOutput := magnetsStreams.Out.(*bytes.Buffer).String()
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(magnetsOutput)), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if envelope["kind"] != "magnet" {
+		t.Errorf("kind = %v, want magnet", envelope["kind"])
+	}
+	if envelope["ref"] != "SSIS-001" {
+		t.Errorf("ref = %v, want SSIS-001", envelope["ref"])
 	}
 }

--- a/internal/cli/commands/search/search_pipeline_test.go
+++ b/internal/cli/commands/search/search_pipeline_test.go
@@ -41,6 +41,31 @@ func TestSearchTextStdinBatchConsumesKeywords(t *testing.T) {
 	}
 }
 
+// TestSearchPositionalNonTTYUsesStablePipelineRecord 验证单个位置参数在非 TTY
+// stdout 下不再调用 Legacy 人类列表渲染，而是输出可供下游消费的番号记录。
+func TestSearchPositionalNonTTYUsesStablePipelineRecord(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	t.Setenv("HOMEDRIVE", filepath.VolumeName(t.TempDir()))
+	t.Setenv("HOMEPATH", strings.TrimPrefix(t.TempDir(), filepath.VolumeName(t.TempDir())))
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{
+			"movies": []map[string]any{{"number": "SSIS-001", "id": "id-1", "title": "Mock"}},
+		}})
+	}))
+	defer server.Close()
+
+	streams := invocation.NewStreams(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	cmd := New(&invocation.RootOptions{Host: server.URL}, streams)
+	cmd.SetArgs([]string{"SSIS"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got := streams.Out.(*bytes.Buffer).String(); got != "SSIS-001\n" {
+		t.Fatalf("non-TTY positional output = %q, want stable ref record", got)
+	}
+}
+
 // TestSearchNDJSONBatchRejectsWrongKind NDJSON 批处理：不兼容 kind 原位错误。
 func TestSearchNDJSONBatchRejectsWrongKind(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())

--- a/internal/cli/commands/search/search_pipeline_test.go
+++ b/internal/cli/commands/search/search_pipeline_test.go
@@ -7,11 +7,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	magnetscmd "github.com/FlanChanXwO/javdb-cli/internal/cli/commands/magnets"
 	"github.com/FlanChanXwO/javdb-cli/internal/cli/invocation"
+	"github.com/FlanChanXwO/javdb-cli/internal/cli/pipeline"
 )
 
 type failingWriter struct{ err error }
@@ -134,6 +137,110 @@ func TestSearchNDJSONFanOutMultipleMovies(t *testing.T) {
 		if envelope["kind"] != "movie" {
 			t.Errorf("line %d kind = %v, want movie", i, envelope["kind"])
 		}
+	}
+}
+
+// TestSearchNamedFanOutStableRefs 验证命名实体搜索按实体逐项输出，非 TTY
+// 文本与 NDJSON 的 ref 都来自实体本身，不回退为原始关键词。
+func TestSearchNamedFanOutStableRefs(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	t.Setenv("HOMEDRIVE", filepath.VolumeName(t.TempDir()))
+	t.Setenv("HOMEPATH", strings.TrimPrefix(t.TempDir(), filepath.VolumeName(t.TempDir())))
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{
+			"actors": []map[string]any{
+				{"id": "actor-1", "name": "Actor One"},
+				{"id": "actor-2", "name_zht": "Actor Two"},
+			},
+		}})
+	}))
+	defer server.Close()
+
+	textStreams := invocation.NewStreams(strings.NewReader("keyword\n"), &bytes.Buffer{}, &bytes.Buffer{})
+	textCmd := New(&invocation.RootOptions{Host: server.URL}, textStreams)
+	textCmd.SetArgs([]string{"--type", "actor"})
+	if err := textCmd.Execute(); err != nil {
+		t.Fatalf("text execute: %v", err)
+	}
+	if got := textStreams.Out.(*bytes.Buffer).String(); got != "Actor One\nActor Two\n" {
+		t.Fatalf("named text output = %q", got)
+	}
+
+	ndjsonStreams := invocation.NewStreams(strings.NewReader("keyword\n"), &bytes.Buffer{}, &bytes.Buffer{})
+	ndjsonCmd := New(&invocation.RootOptions{Host: server.URL}, ndjsonStreams)
+	ndjsonCmd.SetArgs([]string{"--type", "actor", "--ndjson"})
+	if err := ndjsonCmd.Execute(); err != nil {
+		t.Fatalf("ndjson execute: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(ndjsonStreams.Out.(*bytes.Buffer).String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("named NDJSON lines = %d, want 2", len(lines))
+	}
+	for i, want := range []string{"Actor One", "Actor Two"} {
+		var envelope map[string]any
+		if err := json.Unmarshal([]byte(lines[i]), &envelope); err != nil {
+			t.Fatal(err)
+		}
+		if envelope["kind"] != "actor" || envelope["ref"] != want {
+			t.Errorf("line %d envelope = %v", i, envelope)
+		}
+	}
+}
+
+// TestSearchMagnetsPassesThroughErrorEnvelope 验证上游错误不触发搜索请求，
+// 且 NDJSON 中保留原错误信封内容。
+func TestSearchMagnetsPassesThroughErrorEnvelope(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	t.Setenv("HOMEDRIVE", filepath.VolumeName(t.TempDir()))
+	t.Setenv("HOMEPATH", strings.TrimPrefix(t.TempDir(), filepath.VolumeName(t.TempDir())))
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		http.NotFound(writer, request)
+	}))
+	defer server.Close()
+
+	input := `{"schema":"javdb.pipeline/v1","kind":"error","ref":"ABC-123","data":{"command":"upstream","stage":"resolve","code":"missing","message":"not found"}}` + "\n"
+	streams := invocation.NewStreams(strings.NewReader(input), &bytes.Buffer{}, &bytes.Buffer{})
+	cmd := New(&invocation.RootOptions{Host: server.URL}, streams)
+	cmd.SetArgs([]string{"--magnets", "0", "--ndjson"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "1 of 1") {
+		t.Fatalf("error = %v, want propagated failure summary", err)
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("requests = %d, want 0", requests.Load())
+	}
+	wantEnvelope, err := pipeline.DecodeNDJSON(strings.TrimSpace(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotEnvelope, err := pipeline.DecodeNDJSON(strings.TrimSpace(streams.Out.(*bytes.Buffer).String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(gotEnvelope, wantEnvelope) {
+		t.Fatalf("propagated envelope = %#v, want %#v", gotEnvelope, wantEnvelope)
+	}
+
+	wrongKindInput := `{"schema":"javdb.pipeline/v1","kind":"actor","ref":"Actor One","id":"actor-1"}` + "\n"
+	wrongKindStreams := invocation.NewStreams(strings.NewReader(wrongKindInput), &bytes.Buffer{}, &bytes.Buffer{})
+	wrongKindCmd := New(&invocation.RootOptions{Host: server.URL}, wrongKindStreams)
+	wrongKindCmd.SetArgs([]string{"--magnets", "0", "--ndjson"})
+	if err := wrongKindCmd.Execute(); err == nil || !strings.Contains(err.Error(), "1 of 1") {
+		t.Fatalf("wrong-kind error = %v", err)
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("wrong-kind requests = %d, want 0", requests.Load())
+	}
+	wrongKindEnvelope, err := pipeline.DecodeNDJSON(strings.TrimSpace(wrongKindStreams.Out.(*bytes.Buffer).String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wrongKindEnvelope.Kind != pipeline.KindError || wrongKindEnvelope.Data["code"] != "kind" {
+		t.Fatalf("wrong-kind envelope = %#v", wrongKindEnvelope)
 	}
 }
 

--- a/internal/cli/commands/search/search_pipeline_test.go
+++ b/internal/cli/commands/search/search_pipeline_test.go
@@ -373,3 +373,64 @@ func TestSearchPipelineToMagnets(t *testing.T) {
 		t.Errorf("ref = %v, want SSIS-001", envelope["ref"])
 	}
 }
+
+// TestSearchTextPipelineToMagnets 验证默认非 TTY 文本链路只传递稳定番号，且
+// magnets 最终只投影磁力 URI；这是用户实际 `search SSIS | magnets` 的路径。
+func TestSearchTextPipelineToMagnets(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	t.Setenv("HOMEDRIVE", filepath.VolumeName(t.TempDir()))
+	t.Setenv("HOMEPATH", strings.TrimPrefix(t.TempDir(), filepath.VolumeName(t.TempDir())))
+	searchQueries := make([]string, 0, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v2/search":
+			searchQueries = append(searchQueries, request.URL.Query().Get("q"))
+			_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{
+				"movies": []map[string]any{{"number": "SSIS-001", "id": "id-1", "title": "Mock"}},
+			}})
+		case "/api/v4/movies/id-1":
+			_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{
+				"movie": map[string]any{"magnets_count": float64(1)},
+			}})
+		case "/api/v1/movies/id-1/magnets":
+			_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{
+				"magnets": []map[string]any{{"name": "HD", "hash": "AAA", "size": float64(4096), "hd": true}},
+			}})
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	// Step 1: 单个位置参数且非 TTY 时仅产生稳定番号，不包含标题或表格列。
+	searchStreams := invocation.NewStreams(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	searchCmd := New(&invocation.RootOptions{Host: server.URL}, searchStreams)
+	searchCmd.SetArgs([]string{"SSIS"})
+	if err := searchCmd.Execute(); err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	searchOutput := searchStreams.Out.(*bytes.Buffer).String()
+	if searchOutput != "SSIS-001\n" {
+		t.Fatalf("search output = %q, want only stable movie record", searchOutput)
+	}
+	if got := searchStreams.Err.(*bytes.Buffer).String(); got != "" {
+		t.Fatalf("search stderr = %q, want empty", got)
+	}
+
+	// Step 2: 默认文本 magnets 从上一步 stdout 读取番号，并仅输出磁力 URI。
+	magnetsStreams := invocation.NewStreams(strings.NewReader(searchOutput), &bytes.Buffer{}, &bytes.Buffer{})
+	magnetsCmd := magnetscmd.New(&invocation.RootOptions{Host: server.URL}, magnetsStreams)
+	if err := magnetsCmd.Execute(); err != nil {
+		t.Fatalf("magnets: %v", err)
+	}
+	if got := magnetsStreams.Out.(*bytes.Buffer).String(); got != "magnet:?xt=urn:btih:AAA\n" {
+		t.Fatalf("magnets output = %q, want only magnet URI", got)
+	}
+	if got := magnetsStreams.Err.(*bytes.Buffer).String(); got != "" {
+		t.Fatalf("magnets stderr = %q, want empty", got)
+	}
+	if got, want := strings.Join(searchQueries, ","), "SSIS,SSIS-001"; got != want {
+		t.Fatalf("search queries = %q, want %q", got, want)
+	}
+}

--- a/internal/cli/commands/search/search_pipeline_test.go
+++ b/internal/cli/commands/search/search_pipeline_test.go
@@ -3,6 +3,7 @@ package search
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -12,6 +13,10 @@ import (
 	magnetscmd "github.com/FlanChanXwO/javdb-cli/internal/cli/commands/magnets"
 	"github.com/FlanChanXwO/javdb-cli/internal/cli/invocation"
 )
+
+type failingWriter struct{ err error }
+
+func (w failingWriter) Write([]byte) (int, error) { return 0, w.err }
 
 // TestSearchTextStdinBatchConsumesKeywords 文本 stdin 批处理：逐关键词搜索并
 // 按 fan-out 输出每部影片的番号，顺序保持。
@@ -237,6 +242,70 @@ func TestSearchMagnetsJSONPartialFailureReturnsError(t *testing.T) {
 	failed, _ := movies[1].(map[string]any)
 	if failed["error"] == nil || failed["error"] == "" {
 		t.Fatalf("failed movie missing error detail: %v", failed)
+	}
+}
+
+// TestSearchMagnetsTextPropagatesWriteErrors 验证磁力文本路径向上返回 stdout
+// 和 stderr 的写入错误，避免下游关闭 pipe 后仍报告正常成功。
+func TestSearchMagnetsTextPropagatesWriteErrors(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	t.Setenv("HOMEDRIVE", filepath.VolumeName(t.TempDir()))
+	t.Setenv("HOMEPATH", strings.TrimPrefix(t.TempDir(), filepath.VolumeName(t.TempDir())))
+	for _, tc := range []struct {
+		name       string
+		magnets404 bool
+		out        failingWriter
+		errW       failingWriter
+		want       string
+	}{
+		{name: "stdout", out: failingWriter{err: errors.New("stdout closed")}, want: "stdout closed"},
+		{name: "stderr", magnets404: true, errW: failingWriter{err: errors.New("stderr closed")}, want: "stderr closed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				switch request.URL.Path {
+				case "/api/v2/search":
+					_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{
+						"movies": []map[string]any{{"number": "SSIS-001", "id": "id-1"}},
+					}})
+				case "/api/v1/movies/id-1/magnets":
+					if tc.magnets404 {
+						http.NotFound(writer, request)
+						return
+					}
+					_ = json.NewEncoder(writer).Encode(map[string]any{"success": true, "data": map[string]any{
+						"magnets": []map[string]any{{"hash": "AAA"}},
+					}})
+				default:
+					http.NotFound(writer, request)
+				}
+			}))
+			defer server.Close()
+
+			var out, errOut bytes.Buffer
+			outWriter := &out
+			if tc.out.err != nil {
+				outWriter = nil
+			}
+			errWriter := &errOut
+			if tc.errW.err != nil {
+				errWriter = nil
+			}
+			streams := invocation.NewStreams(strings.NewReader("SSIS\n"), outWriter, errWriter)
+			if tc.out.err != nil {
+				streams.Out = tc.out
+			}
+			if tc.errW.err != nil {
+				streams.Err = tc.errW
+			}
+			cmd := New(&invocation.RootOptions{Host: server.URL}, streams)
+			cmd.SetArgs([]string{"--magnets", "0"})
+			err := cmd.Execute()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/commands/search/search_test.go
+++ b/internal/cli/commands/search/search_test.go
@@ -92,6 +92,8 @@ func TestExecuteNamedText(t *testing.T) {
 	defer server.Close()
 
 	streams := invocation.NewStreams(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	// 人类命名实体文本只在 TTY stdout 下验证；非 TTY 默认是稳定记录管道。
+	streams.OutIsTerminal = true
 	cmd := New(&invocation.RootOptions{Host: server.URL}, streams)
 	cmd.SetArgs([]string{"kw", "--type", "actor"})
 	if err := cmd.Execute(); err != nil {

--- a/internal/cli/commands/search/search_test.go
+++ b/internal/cli/commands/search/search_test.go
@@ -46,6 +46,30 @@ func TestSearchTypeKey(t *testing.T) {
 	}
 }
 
+func TestSearchMagnetsFlagValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "cnsub requires magnets", args: []string{"--cnsub"}, want: "require --magnets"},
+		{name: "hd requires magnets", args: []string{"--hd"}, want: "require --magnets"},
+		{name: "min-size requires magnets", args: []string{"--min-size", "500MB"}, want: "require --magnets"},
+		{name: "magnets rejects negative", args: []string{"--magnets", "-1"}, want: "--magnets must be >= 0"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			streams := invocation.NewStreams(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+			cmd := New(&invocation.RootOptions{}, streams)
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
 // TestExecuteMoviesJSONHasMagnetsFilter 覆盖 movie 分支 JSON + has-magnets 过滤。
 func TestExecuteMoviesJSONHasMagnetsFilter(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())

--- a/internal/cli/commands/tags/tags_test.go
+++ b/internal/cli/commands/tags/tags_test.go
@@ -2,9 +2,11 @@ package tags
 
 import (
 	"bytes"
-	"github.com/FlanChanXwO/javdb-cli/internal/cli/invocation"
 	"strings"
 	"testing"
+
+	"github.com/FlanChanXwO/javdb-cli/internal/cli/invocation"
+	storagetags "github.com/FlanChanXwO/javdb-cli/internal/storage/tags"
 )
 
 func TestNewHelpListsFlags(t *testing.T) {
@@ -21,5 +23,40 @@ func TestNewHelpListsFlags(t *testing.T) {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("help missing %s", want)
 		}
+	}
+}
+
+func TestNewTextAndHumanOutputModes(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	path, err := storagetags.Path("censored")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := storagetags.Save(path, &storagetags.Doc{
+		Zone:       "censored",
+		Categories: []storagetags.Category{{ID: "cat-1", NameEN: "General", Tags: []storagetags.Tag{{ID: "tag-1", NameEN: "Tag One", NameZH: "标签一"}}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	textStreams := invocation.NewStreams(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	textCmd := New(&invocation.RootOptions{Host: "https://example.invalid"}, textStreams)
+	if err := textCmd.Execute(); err != nil {
+		t.Fatalf("text execute: %v", err)
+	}
+	if got := textStreams.Out.(*bytes.Buffer).String(); got != "Tag One\n" {
+		t.Fatalf("non-TTY output = %q, want stable ref", got)
+	}
+
+	humanStreams := invocation.NewStreams(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	humanStreams.OutIsTerminal = true
+	humanCmd := New(&invocation.RootOptions{Host: "https://example.invalid"}, humanStreams)
+	if err := humanCmd.Execute(); err != nil {
+		t.Fatalf("human execute: %v", err)
+	}
+	if got := humanStreams.Out.(*bytes.Buffer).String(); !strings.Contains(got, "# cat-1\tGeneral") || !strings.Contains(got, "tag-1\tTag One\t标签一") {
+		t.Fatalf("TTY output = %q, want taxonomy table", got)
 	}
 }

--- a/internal/cli/invocation/invocation.go
+++ b/internal/cli/invocation/invocation.go
@@ -21,6 +21,11 @@ type Streams struct {
 	// InIsTerminal 标记 stdin 是否为交互终端；由根命令入口探测，测试可显式设置。
 	// 非 TTY stdin 是管道/批处理输入的信号，命令据此选择输入分类。
 	InIsTerminal bool
+
+	// OutIsTerminal 标记 stdout 是否为交互终端；由根命令入口探测，测试可显式
+	// 设置。非 TTY stdout 时默认输出稳定记录流（一行一个 ref/URI），TTY 时
+	// 使用人类文本渲染。显式 --json/--ndjson 不受此标记影响。
+	OutIsTerminal bool
 }
 
 // NewStreams 构造 Streams。

--- a/internal/cli/pipeline/consumer.go
+++ b/internal/cli/pipeline/consumer.go
@@ -53,6 +53,13 @@ func (c *Consumer) Execute(streams *invocation.Streams, args []string, ndjson, j
 
 // RunInputs 按输出模式处理已收集的输入；单项失败原位错误信封并继续。
 // 调用方（如 search）可自行完成图片分类后复用本方法。
+//
+// 文本/人类模式（OutputText/OutputHuman）下：
+//   - 成功项：若 RenderText 已设置则调用它渲染人类/稳定文本，否则逐行 ref。
+//   - 失败项：错误原因写 stderr，不向 stdout 写任何内容（不伪造成功 ref）。
+//
+// NDJSON/JSON 模式下：失败项原位 error 信封写入 stdout（机器契约），保持
+// 输出顺序与单项错误可观测性。
 func (c *Consumer) RunInputs(streams *invocation.Streams, inputs []Envelope, mode OutputMode) error {
 	// legacy JSON shape 只适用于纯文本 ref 输入；NDJSON 信封先过 kind 校验。
 	if mode == OutputJSON && len(inputs) == 1 && inputs[0].Kind == "" && c.LegacyJSON != nil {
@@ -64,6 +71,35 @@ func (c *Consumer) RunInputs(streams *invocation.Streams, inputs []Envelope, mod
 			return err
 		}
 		return c.LegacyJSON(streams.Out, output)
+	}
+
+	// 文本/人类模式：成功项按 RenderText 或 ref 写 stdout，失败项写 stderr。
+	if mode == OutputText || mode == OutputHuman {
+		failures := 0
+		for _, input := range inputs {
+			if !c.accepts(input) {
+				failures++
+				fmt.Fprintf(streams.Err, "%s: %s\n", c.Name, fmt.Sprintf("unsupported kind %q", input.Kind))
+				continue
+			}
+			output, err := c.RunOne(context.Background(), input)
+			if err != nil {
+				failures++
+				fmt.Fprintf(streams.Err, "%s: %s\n", c.Name, err.Error())
+				continue
+			}
+			if c.RenderText != nil {
+				if err := c.RenderText(streams.Out, output); err != nil {
+					return err
+				}
+			} else if err := writeRef(streams.Out, output); err != nil {
+				return err
+			}
+		}
+		if failures > 0 {
+			return fmt.Errorf("%s completed with %d of %d items failed", c.Name, failures, len(inputs))
+		}
+		return nil
 	}
 
 	writer := NewWriter(streams.Out, mode)
@@ -93,6 +129,19 @@ func (c *Consumer) RunInputs(streams *invocation.Streams, inputs []Envelope, mod
 		return fmt.Errorf("%s completed with %d of %d items failed", c.Name, failures, len(inputs))
 	}
 	return nil
+}
+
+// writeRef 写出信封的稳定引用（优先 ref，否则 id），不含错误信封。
+func writeRef(w io.Writer, envelope Envelope) error {
+	ref := envelope.Ref
+	if ref == "" {
+		ref = envelope.ID
+	}
+	if ref == "" {
+		return fmt.Errorf("envelope has no printable ref or id")
+	}
+	_, err := fmt.Fprintln(w, ref)
+	return err
 }
 
 // CollectInputs 统一收集输入：位置参数（单个）或非 TTY stdin 批。

--- a/internal/cli/pipeline/consumer.go
+++ b/internal/cli/pipeline/consumer.go
@@ -94,7 +94,9 @@ func (c *Consumer) RunInputs(streams *invocation.Streams, inputs []Envelope, mod
 		for _, r := range results {
 			if r.err != nil {
 				failures++
-				fmt.Fprintf(streams.Err, "%s: %s\n", c.Name, r.err.Error())
+				if _, err := fmt.Fprintf(streams.Err, "%s: %s\n", c.Name, r.err.Error()); err != nil {
+					return err
+				}
 				continue
 			}
 			for _, output := range r.outputs {

--- a/internal/cli/pipeline/consumer.go
+++ b/internal/cli/pipeline/consumer.go
@@ -32,7 +32,7 @@ type Consumer struct {
 
 // Execute 是命令 RunE 的通用实现（不消费图片；需要图片输入的调用方自行先行处理）。
 func (c *Consumer) Execute(streams *invocation.Streams, args []string, ndjson, json bool) error {
-	mode, err := ResolveOutputMode(ndjson, json)
+	mode, err := ResolveOutputMode(ndjson, json, streams.OutIsTerminal)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/pipeline/consumer.go
+++ b/internal/cli/pipeline/consumer.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/FlanChanXwO/javdb-cli/internal/cli/invocation"
 )
@@ -30,6 +31,9 @@ type Consumer struct {
 	RenderText func(io.Writer, Envelope) error
 	// LegacyJSON 输出单项显式 --json 的既有 shape；nil 时输出信封对象。
 	LegacyJSON func(io.Writer, Envelope) error
+	// Concurrency 控制批量执行并发度；<= 0 表示串行。并发时结果按输入顺序
+	// 写出，单项失败不阻塞其他项。
+	Concurrency int
 }
 
 // Execute 是命令 RunE 的通用实现（不消费图片；需要图片输入的调用方自行先行处理）。
@@ -62,6 +66,8 @@ func (c *Consumer) Execute(streams *invocation.Streams, args []string, ndjson, j
 //
 // NDJSON/JSON 模式下：失败项原位 error 信封写入 stdout（机器契约），保持
 // 输出顺序与单项错误可观测性。
+//
+// Concurrency > 0 时批量请求并发执行，结果按输入顺序写出。
 func (c *Consumer) RunInputs(streams *invocation.Streams, inputs []Envelope, mode OutputMode) error {
 	// legacy JSON shape 只适用于纯文本 ref 输入；NDJSON 信封先过 kind 校验。
 	if mode == OutputJSON && len(inputs) == 1 && inputs[0].Kind == "" && c.LegacyJSON != nil {
@@ -79,32 +85,19 @@ func (c *Consumer) RunInputs(streams *invocation.Streams, inputs []Envelope, mod
 		return c.LegacyJSON(streams.Out, Envelope{})
 	}
 
+	// 并发或串行执行全部输入，收集按索引排序的结果。
+	results := c.processAll(inputs)
+
 	// 文本/人类模式：成功项按 RenderText 或 ref 写 stdout，失败项写 stderr。
 	if mode == OutputText || mode == OutputHuman {
 		failures := 0
-		for _, input := range inputs {
-			// kind:error 透传：不重新执行或包装，错误原因写 stderr。
-			if input.Kind == KindError {
+		for _, r := range results {
+			if r.err != nil {
 				failures++
-				msg := input.Data["message"]
-				if msg == nil {
-					msg = "upstream error"
-				}
-				fmt.Fprintf(streams.Err, "%s: %s\n", c.Name, msg)
+				fmt.Fprintf(streams.Err, "%s: %s\n", c.Name, r.err.Error())
 				continue
 			}
-			if !c.accepts(input) {
-				failures++
-				fmt.Fprintf(streams.Err, "%s: %s\n", c.Name, fmt.Sprintf("unsupported kind %q", input.Kind))
-				continue
-			}
-			outputs, err := c.runItem(input)
-			if err != nil {
-				failures++
-				fmt.Fprintf(streams.Err, "%s: %s\n", c.Name, err.Error())
-				continue
-			}
-			for _, output := range outputs {
+			for _, output := range r.outputs {
 				if c.RenderText != nil {
 					if err := c.RenderText(streams.Out, output); err != nil {
 						return err
@@ -122,32 +115,14 @@ func (c *Consumer) RunInputs(streams *invocation.Streams, inputs []Envelope, mod
 
 	writer := NewWriter(streams.Out, mode)
 	failures := 0
-	for _, input := range inputs {
-		// kind:error 透传：不重新执行或包装，原样写出。
-		if input.Kind == KindError {
-			failures++
-			if err := writer.Write(input); err != nil {
-				return err
-			}
-			continue
-		}
-		if !c.accepts(input) {
-			failures++
-			output := ErrorEnvelope(input, c.Name, "input", "kind", fmt.Sprintf("unsupported kind %q", input.Kind))
+	for _, r := range results {
+		for _, output := range r.envelopes {
 			if err := writer.Write(output); err != nil {
 				return err
 			}
-			continue
 		}
-		outputs, err := c.runItem(input)
-		if err != nil {
+		if r.err != nil {
 			failures++
-			outputs = []Envelope{ErrorEnvelope(input, c.Name, "batch", "item", err.Error())}
-		}
-		for _, output := range outputs {
-			if err := writer.Write(output); err != nil {
-				return err
-			}
 		}
 	}
 	if err := writer.Finish(); err != nil {
@@ -157,6 +132,63 @@ func (c *Consumer) RunInputs(streams *invocation.Streams, inputs []Envelope, mod
 		return fmt.Errorf("%s completed with %d of %d items failed", c.Name, failures, len(inputs))
 	}
 	return nil
+}
+
+// itemResult 是单项处理的结果。
+type itemResult struct {
+	// outputs 用于文本/人类模式：成功时包含输出信封，失败时为空。
+	outputs []Envelope
+	// envelopes 用于 NDJSON/JSON 模式：成功时为输出信封，失败时为原位 error 信封。
+	envelopes []Envelope
+	// err 非 nil 表示该项失败（文本模式写 stderr，NDJSON 模式用 envelopes 中的 error 信封）。
+	err error
+}
+
+// processAll 执行全部输入并返回按索引排序的结果。Concurrency > 0 时并发执行。
+func (c *Consumer) processAll(inputs []Envelope) []itemResult {
+	results := make([]itemResult, len(inputs))
+	if c.Concurrency > 0 && len(inputs) > 1 {
+		var wait sync.WaitGroup
+		wait.Add(len(inputs))
+		for index, input := range inputs {
+			go func(index int, input Envelope) {
+				defer wait.Done()
+				results[index] = c.processOne(input)
+			}(index, input)
+		}
+		wait.Wait()
+		return results
+	}
+	for index, input := range inputs {
+		results[index] = c.processOne(input)
+	}
+	return results
+}
+
+// processOne 处理单项输入并返回结果。
+func (c *Consumer) processOne(input Envelope) itemResult {
+	// kind:error 透传：不重新执行或包装。
+	if input.Kind == KindError {
+		return itemResult{
+			envelopes: []Envelope{input},
+			err:       fmt.Errorf("%s", input.Data["message"]),
+		}
+	}
+	if !c.accepts(input) {
+		err := fmt.Errorf("unsupported kind %q", input.Kind)
+		return itemResult{
+			envelopes: []Envelope{ErrorEnvelope(input, c.Name, "input", "kind", err.Error())},
+			err:       err,
+		}
+	}
+	outputs, err := c.runItem(input)
+	if err != nil {
+		return itemResult{
+			envelopes: []Envelope{ErrorEnvelope(input, c.Name, "batch", "item", err.Error())},
+			err:       err,
+		}
+	}
+	return itemResult{outputs: outputs, envelopes: outputs}
 }
 
 // writeRef 写出信封的稳定引用（优先 ref，否则 id），不含错误信封。

--- a/internal/cli/pipeline/consumer.go
+++ b/internal/cli/pipeline/consumer.go
@@ -77,6 +77,16 @@ func (c *Consumer) RunInputs(streams *invocation.Streams, inputs []Envelope, mod
 	if mode == OutputText || mode == OutputHuman {
 		failures := 0
 		for _, input := range inputs {
+			// kind:error 透传：不重新执行或包装，错误原因写 stderr。
+			if input.Kind == KindError {
+				failures++
+				msg := input.Data["message"]
+				if msg == nil {
+					msg = "upstream error"
+				}
+				fmt.Fprintf(streams.Err, "%s: %s\n", c.Name, msg)
+				continue
+			}
 			if !c.accepts(input) {
 				failures++
 				fmt.Fprintf(streams.Err, "%s: %s\n", c.Name, fmt.Sprintf("unsupported kind %q", input.Kind))
@@ -105,6 +115,14 @@ func (c *Consumer) RunInputs(streams *invocation.Streams, inputs []Envelope, mod
 	writer := NewWriter(streams.Out, mode)
 	failures := 0
 	for _, input := range inputs {
+		// kind:error 透传：不重新执行或包装，原样写出。
+		if input.Kind == KindError {
+			failures++
+			if err := writer.Write(input); err != nil {
+				return err
+			}
+			continue
+		}
 		if !c.accepts(input) {
 			failures++
 			output := ErrorEnvelope(input, c.Name, "input", "kind", fmt.Sprintf("unsupported kind %q", input.Kind))

--- a/internal/cli/pipeline/consumer.go
+++ b/internal/cli/pipeline/consumer.go
@@ -31,6 +31,8 @@ type Consumer struct {
 	RunMany func(context.Context, Envelope) ([]Envelope, error)
 	// RenderText 输出默认的人类文本。
 	RenderText func(io.Writer, Envelope) error
+	// RenderError 将文本/人类模式的单项错误写到 stderr；nil 使用 Name 前缀。
+	RenderError func(io.Writer, error) error
 	// LegacyJSON 输出单项显式 --json 的既有 shape；nil 时输出信封对象。
 	LegacyJSON func(io.Writer, Envelope) error
 	// Concurrency 控制批量执行并发度；<= 0 表示串行。并发时结果按输入顺序
@@ -96,7 +98,7 @@ func (c *Consumer) RunInputs(streams *invocation.Streams, inputs []Envelope, mod
 		for _, r := range results {
 			if r.err != nil {
 				failures++
-				if _, err := fmt.Fprintf(streams.Err, "%s: %s\n", c.Name, r.err.Error()); err != nil {
+				if err := c.renderError(streams.Err, r.err); err != nil {
 					return err
 				}
 				continue
@@ -136,6 +138,14 @@ func (c *Consumer) RunInputs(streams *invocation.Streams, inputs []Envelope, mod
 		return fmt.Errorf("%s completed with %d of %d items failed", c.Name, failures, len(inputs))
 	}
 	return nil
+}
+
+func (c *Consumer) renderError(w io.Writer, itemErr error) error {
+	if c.RenderError != nil {
+		return c.RenderError(w, itemErr)
+	}
+	_, err := fmt.Fprintf(w, "%s: %s\n", c.Name, itemErr.Error())
+	return err
 }
 
 // itemResult 是单项处理的结果。

--- a/internal/cli/pipeline/consumer.go
+++ b/internal/cli/pipeline/consumer.go
@@ -24,6 +24,8 @@ type Consumer struct {
 	AcceptedKinds []Kind
 	// RunOne 执行单项并返回输出信封。
 	RunOne func(context.Context, Envelope) (Envelope, error)
+	// RunMany 执行单项并返回多个输出信封（fan-out）；设置时优先于 RunOne。
+	RunMany func(context.Context, Envelope) ([]Envelope, error)
 	// RenderText 输出默认的人类文本。
 	RenderText func(io.Writer, Envelope) error
 	// LegacyJSON 输出单项显式 --json 的既有 shape；nil 时输出信封对象。
@@ -63,14 +65,18 @@ func (c *Consumer) Execute(streams *invocation.Streams, args []string, ndjson, j
 func (c *Consumer) RunInputs(streams *invocation.Streams, inputs []Envelope, mode OutputMode) error {
 	// legacy JSON shape 只适用于纯文本 ref 输入；NDJSON 信封先过 kind 校验。
 	if mode == OutputJSON && len(inputs) == 1 && inputs[0].Kind == "" && c.LegacyJSON != nil {
-		output, err := c.RunOne(context.Background(), inputs[0])
+		outputs, err := c.runItem(inputs[0])
 		if err != nil {
 			if legacyErr := c.LegacyJSON(streams.Out, ErrorEnvelope(inputs[0], c.Name, "batch", "item", err.Error())); legacyErr != nil {
 				return legacyErr
 			}
 			return err
 		}
-		return c.LegacyJSON(streams.Out, output)
+		// legacy JSON 只接受单项输出；RunMany fan-out 在非 legacy 路径处理。
+		if len(outputs) > 0 {
+			return c.LegacyJSON(streams.Out, outputs[0])
+		}
+		return c.LegacyJSON(streams.Out, Envelope{})
 	}
 
 	// 文本/人类模式：成功项按 RenderText 或 ref 写 stdout，失败项写 stderr。
@@ -92,18 +98,20 @@ func (c *Consumer) RunInputs(streams *invocation.Streams, inputs []Envelope, mod
 				fmt.Fprintf(streams.Err, "%s: %s\n", c.Name, fmt.Sprintf("unsupported kind %q", input.Kind))
 				continue
 			}
-			output, err := c.RunOne(context.Background(), input)
+			outputs, err := c.runItem(input)
 			if err != nil {
 				failures++
 				fmt.Fprintf(streams.Err, "%s: %s\n", c.Name, err.Error())
 				continue
 			}
-			if c.RenderText != nil {
-				if err := c.RenderText(streams.Out, output); err != nil {
+			for _, output := range outputs {
+				if c.RenderText != nil {
+					if err := c.RenderText(streams.Out, output); err != nil {
+						return err
+					}
+				} else if err := writeRef(streams.Out, output); err != nil {
 					return err
 				}
-			} else if err := writeRef(streams.Out, output); err != nil {
-				return err
 			}
 		}
 		if failures > 0 {
@@ -131,13 +139,15 @@ func (c *Consumer) RunInputs(streams *invocation.Streams, inputs []Envelope, mod
 			}
 			continue
 		}
-		output, err := c.RunOne(context.Background(), input)
+		outputs, err := c.runItem(input)
 		if err != nil {
 			failures++
-			output = ErrorEnvelope(input, c.Name, "batch", "item", err.Error())
+			outputs = []Envelope{ErrorEnvelope(input, c.Name, "batch", "item", err.Error())}
 		}
-		if err := writer.Write(output); err != nil {
-			return err
+		for _, output := range outputs {
+			if err := writer.Write(output); err != nil {
+				return err
+			}
 		}
 	}
 	if err := writer.Finish(); err != nil {
@@ -160,6 +170,18 @@ func writeRef(w io.Writer, envelope Envelope) error {
 	}
 	_, err := fmt.Fprintln(w, ref)
 	return err
+}
+
+// runItem 执行单项并返回输出信封列表；RunMany 优先于 RunOne（fan-out）。
+func (c *Consumer) runItem(input Envelope) ([]Envelope, error) {
+	if c.RunMany != nil {
+		return c.RunMany(context.Background(), input)
+	}
+	output, err := c.RunOne(context.Background(), input)
+	if err != nil {
+		return nil, err
+	}
+	return []Envelope{output}, nil
 }
 
 // CollectInputs 统一收集输入：位置参数（单个）或非 TTY stdin 批。

--- a/internal/cli/pipeline/consumer.go
+++ b/internal/cli/pipeline/consumer.go
@@ -21,6 +21,8 @@ const KindTag Kind = "tag"
 //   - 显式 --json：单项走 LegacyJSON 既有 shape，多项输出信封数组。
 type Consumer struct {
 	Name string
+	// Context 是本次命令调用的生命周期；未设置时使用 Background。
+	Context context.Context
 	// AcceptedKinds 是输入项允许的 kind；nil 表示接受任意 kind（文本 ref）。
 	AcceptedKinds []Kind
 	// RunOne 执行单项并返回输出信封。
@@ -150,14 +152,25 @@ type itemResult struct {
 func (c *Consumer) processAll(inputs []Envelope) []itemResult {
 	results := make([]itemResult, len(inputs))
 	if c.Concurrency > 0 && len(inputs) > 1 {
-		var wait sync.WaitGroup
-		wait.Add(len(inputs))
-		for index, input := range inputs {
-			go func(index int, input Envelope) {
-				defer wait.Done()
-				results[index] = c.processOne(input)
-			}(index, input)
+		workers := c.Concurrency
+		if workers > len(inputs) {
+			workers = len(inputs)
 		}
+		jobs := make(chan int)
+		var wait sync.WaitGroup
+		wait.Add(workers)
+		for worker := 0; worker < workers; worker++ {
+			go func() {
+				defer wait.Done()
+				for index := range jobs {
+					results[index] = c.processOne(inputs[index])
+				}
+			}()
+		}
+		for index := range inputs {
+			jobs <- index
+		}
+		close(jobs)
 		wait.Wait()
 		return results
 	}
@@ -208,10 +221,14 @@ func writeRef(w io.Writer, envelope Envelope) error {
 
 // runItem 执行单项并返回输出信封列表；RunMany 优先于 RunOne（fan-out）。
 func (c *Consumer) runItem(input Envelope) ([]Envelope, error) {
-	if c.RunMany != nil {
-		return c.RunMany(context.Background(), input)
+	ctx := c.Context
+	if ctx == nil {
+		ctx = context.Background()
 	}
-	output, err := c.RunOne(context.Background(), input)
+	if c.RunMany != nil {
+		return c.RunMany(ctx, input)
+	}
+	output, err := c.RunOne(ctx, input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/pipeline/consumer_test.go
+++ b/internal/cli/pipeline/consumer_test.go
@@ -75,6 +75,28 @@ func TestConsumerUsesCallContext(t *testing.T) {
 	}
 }
 
+func TestConsumerCustomErrorRenderer(t *testing.T) {
+	streams, _ := testStreams("", false)
+	errBuf := &bytes.Buffer{}
+	streams.Err = errBuf
+	consumer := &Consumer{
+		Name: "internal-name",
+		RenderError: func(w io.Writer, err error) error {
+			_, writeErr := fmt.Fprintf(w, "localized: %s\n", err)
+			return writeErr
+		},
+		RunOne: func(context.Context, Envelope) (Envelope, error) {
+			return Envelope{}, testError("boom")
+		},
+	}
+	if err := consumer.RunInputs(streams, []Envelope{New("", "a", "")}, OutputText); err == nil {
+		t.Fatal("expected item failure")
+	}
+	if got := errBuf.String(); got != "localized: boom\n" {
+		t.Fatalf("stderr = %q, want localized error", got)
+	}
+}
+
 func TestCollectInputsMatrix(t *testing.T) {
 	for _, tc := range []struct {
 		name     string

--- a/internal/cli/pipeline/consumer_test.go
+++ b/internal/cli/pipeline/consumer_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/FlanChanXwO/javdb-cli/internal/cli/invocation"
 	javdb "github.com/FlanChanXwO/javdb-cli/sdk"
@@ -364,5 +365,88 @@ func TestConsumerPassesThroughErrorEnvelope(t *testing.T) {
 	}
 	if streams2.Out.(*bytes.Buffer).String() != "" {
 		t.Errorf("stdout should be empty for error-only input, got %q", streams2.Out.(*bytes.Buffer).String())
+	}
+}
+
+// TestConsumerConcurrencyPreservesOrder 并发模式下结果按输入顺序写出，
+// 即使各项处理耗时不同。
+func TestConsumerConcurrencyPreservesOrder(t *testing.T) {
+	streams, out := testStreams("", false)
+	inputs := []Envelope{
+		New("", "a", ""),
+		New("", "b", ""),
+		New("", "c", ""),
+		New("", "d", ""),
+	}
+	consumer := &Consumer{
+		Name:          "test",
+		AcceptedKinds: []Kind{KindMovie},
+		Concurrency:   1,
+		RunOne: func(ctx context.Context, input Envelope) (Envelope, error) {
+			// 模拟不同耗时：b 最慢，a 最快。
+			delay := map[string]int{"a": 10, "b": 50, "c": 20, "d": 5}[input.Ref]
+			time.Sleep(time.Duration(delay) * time.Millisecond)
+			return New(KindMovie, input.Ref+"-ok", ""), nil
+		},
+	}
+	if err := consumer.RunInputs(streams, inputs, OutputNDJSON); err != nil {
+		t.Fatalf("RunInputs: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("lines = %d, want 4", len(lines))
+	}
+	// 顺序必须与输入一致，不受处理耗时影响。
+	want := []string{"a-ok", "b-ok", "c-ok", "d-ok"}
+	for i, w := range want {
+		var env Envelope
+		if err := json.Unmarshal([]byte(lines[i]), &env); err != nil {
+			t.Fatal(err)
+		}
+		if env.Ref != w {
+			t.Errorf("line %d ref = %s, want %s", i, env.Ref, w)
+		}
+	}
+}
+
+// TestConsumerConcurrencyPartialFailureContinues 并发模式下单项失败不阻塞其他项，
+// 结果仍按输入顺序写出。
+func TestConsumerConcurrencyPartialFailureContinues(t *testing.T) {
+	streams, _ := testStreams("", false)
+	errBuf := &bytes.Buffer{}
+	streams.Err = errBuf
+	inputs := []Envelope{
+		New("", "a", ""),
+		New("", "b", ""),
+		New("", "c", ""),
+	}
+	consumer := &Consumer{
+		Name:          "test",
+		AcceptedKinds: []Kind{KindMovie},
+		Concurrency:   1,
+		RunOne: func(ctx context.Context, input Envelope) (Envelope, error) {
+			if input.Ref == "b" {
+				return Envelope{}, testError("boom")
+			}
+			return New(KindMovie, input.Ref+"-ok", ""), nil
+		},
+	}
+	err := consumer.RunInputs(streams, inputs, OutputNDJSON)
+	if err == nil || !strings.Contains(err.Error(), "1 of 3 items failed") {
+		t.Fatalf("expected 1-of-3 failure, got %v", err)
+	}
+	out := streams.Out.(*bytes.Buffer).String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("lines = %d, want 3", len(lines))
+	}
+	var kinds []string
+	for _, line := range lines {
+		var env Envelope
+		_ = json.Unmarshal([]byte(line), &env)
+		kinds = append(kinds, string(env.Kind))
+	}
+	if kinds[0] != "movie" || kinds[1] != "error" || kinds[2] != "movie" {
+		t.Errorf("kinds = %v, want [movie error movie]", kinds)
 	}
 }

--- a/internal/cli/pipeline/consumer_test.go
+++ b/internal/cli/pipeline/consumer_test.go
@@ -138,7 +138,7 @@ func TestConsumerSingleNDJSONLegacyShape(t *testing.T) {
 	}
 }
 
-func TestListProducerDefaultsToText(t *testing.T) {
+func TestListProducerDefaultsToStableRefs(t *testing.T) {
 	streams, out := testStreams("", false)
 	producer := &ListProducer{
 		Name: "watched",
@@ -155,19 +155,53 @@ func TestListProducerDefaultsToText(t *testing.T) {
 			return map[string]any{"movies": items}, nil
 		},
 		RowText: func(w io.Writer, _ io.Writer, items []map[string]any) error {
-			for _, item := range items {
-				if _, err := fmt.Fprintln(w, item["number"]); err != nil {
-					return err
-				}
-			}
-			return nil
+			_, err := fmt.Fprintln(w, "human table")
+			return err
 		},
 	}
 	if err := producer.Execute(streams, false, false); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 	if out.String() != "SSIS-589\nHZGD-246\n" {
-		t.Errorf("default output = %q", out.String())
+		t.Errorf("non-TTY output = %q, want stable refs", out.String())
+	}
+
+	ttyStreams, ttyOut := testStreams("", true)
+	if err := producer.Execute(ttyStreams, false, false); err != nil {
+		t.Fatalf("Execute TTY: %v", err)
+	}
+	if ttyOut.String() != "human table\n" {
+		t.Errorf("TTY output = %q, want human renderer", ttyOut.String())
+	}
+}
+
+func TestProducerTextAndHumanModes(t *testing.T) {
+	producer := &Producer{
+		Name: "tags",
+		Produce: func(context.Context) ([]Envelope, error) {
+			return []Envelope{New(KindTag, "tag-one", "id-1"), New(KindTag, "", "id-2")}, nil
+		},
+		RenderText: func(w io.Writer, envelopes []Envelope) error {
+			_, err := fmt.Fprintln(w, "# category\nTABLE")
+			return err
+		},
+		LegacyJSON: func(io.Writer) error { return nil },
+	}
+
+	streams, out := testStreams("", false)
+	if err := producer.Execute(streams, false, false); err != nil {
+		t.Fatalf("non-TTY Execute: %v", err)
+	}
+	if out.String() != "tag-one\nid-2\n" {
+		t.Fatalf("non-TTY output = %q, want stable refs", out.String())
+	}
+
+	ttyStreams, ttyOut := testStreams("", true)
+	if err := producer.Execute(ttyStreams, false, false); err != nil {
+		t.Fatalf("TTY Execute: %v", err)
+	}
+	if ttyOut.String() != "# category\nTABLE\n" {
+		t.Fatalf("TTY output = %q, want human renderer", ttyOut.String())
 	}
 }
 

--- a/internal/cli/pipeline/consumer_test.go
+++ b/internal/cli/pipeline/consumer_test.go
@@ -299,6 +299,30 @@ func TestConsumerTextModeErrorsToStderr(t *testing.T) {
 	}
 }
 
+// TestConsumerTextModePropagatesStderrWriteError 下游 stderr 关闭时，文本模式
+// 必须返回写入错误，而不是继续返回批处理汇总或伪造成功。
+func TestConsumerTextModePropagatesStderrWriteError(t *testing.T) {
+	streams, _ := testStreams("", false)
+	streams.Err = failingWriter{}
+	consumer := &Consumer{
+		Name:          "detail",
+		AcceptedKinds: []Kind{KindMovie},
+		RunOne: func(context.Context, Envelope) (Envelope, error) {
+			return Envelope{}, testError("detail failed")
+		},
+	}
+	err := consumer.RunInputs(streams, []Envelope{New("", "SSIS-589", "")}, OutputText)
+	if err == nil || !strings.Contains(err.Error(), "stderr write failed") {
+		t.Fatalf("error = %v, want stderr write error", err)
+	}
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, testError("stderr write failed")
+}
+
 // TestConsumerHumanModeRenderText OutputHuman 模式下成功项走 RenderText。
 func TestConsumerHumanModeRenderText(t *testing.T) {
 	streams, out := testStreams("", false)

--- a/internal/cli/pipeline/consumer_test.go
+++ b/internal/cli/pipeline/consumer_test.go
@@ -324,3 +324,45 @@ func TestConsumerHumanModeRenderText(t *testing.T) {
 		t.Errorf("output = %q, want '>> SSIS-589'", out.String())
 	}
 }
+
+// TestConsumerPassesThroughErrorEnvelope kind:error 输入不重新执行或包装：
+// NDJSON 模式原样写出，文本模式错误原因写 stderr。
+func TestConsumerPassesThroughErrorEnvelope(t *testing.T) {
+	// NDJSON 模式：原样透传。
+	streams, out := testStreams("", false)
+	errInput := ErrorEnvelope(New(KindMovie, "SSIS-589", "id-1"), "upstream", "link", "resolve", "not found")
+	consumer := &Consumer{
+		Name:          "magnets",
+		AcceptedKinds: []Kind{KindMovie},
+		RunOne: func(ctx context.Context, input Envelope) (Envelope, error) {
+			t.Fatal("RunOne must not be called for kind:error input")
+			return Envelope{}, nil
+		},
+	}
+	err := consumer.RunInputs(streams, []Envelope{errInput}, OutputNDJSON)
+	if err == nil || !strings.Contains(err.Error(), "1 of 1 items failed") {
+		t.Fatalf("expected failure summary, got %v", err)
+	}
+	var parsed Envelope
+	if e := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &parsed); e != nil {
+		t.Fatal(e)
+	}
+	if parsed.Kind != KindError || parsed.Data["code"] != "resolve" {
+		t.Errorf("passthrough envelope = %+v, want kind=error code=resolve", parsed)
+	}
+
+	// 文本模式：错误原因写 stderr。
+	streams2, _ := testStreams("", false)
+	errBuf := &bytes.Buffer{}
+	streams2.Err = errBuf
+	err = consumer.RunInputs(streams2, []Envelope{errInput}, OutputText)
+	if err == nil {
+		t.Fatal("expected failure summary")
+	}
+	if !strings.Contains(errBuf.String(), "not found") {
+		t.Errorf("stderr = %q, want 'not found'", errBuf.String())
+	}
+	if streams2.Out.(*bytes.Buffer).String() != "" {
+		t.Errorf("stdout should be empty for error-only input, got %q", streams2.Out.(*bytes.Buffer).String())
+	}
+}

--- a/internal/cli/pipeline/consumer_test.go
+++ b/internal/cli/pipeline/consumer_test.go
@@ -262,3 +262,65 @@ func TestBatchRunnerTTYStdoutRoutesToLegacy(t *testing.T) {
 		t.Error("TTY stdout must route single text input through the legacy human path")
 	}
 }
+
+// TestConsumerTextModeErrorsToStderr 文本/人类模式下失败项只写 stderr，
+// 不向 stdout 输出任何内容（不伪造成功 ref）；成功项写 stdout。
+func TestConsumerTextModeErrorsToStderr(t *testing.T) {
+	streams, out := testStreams("a\nb\nc\n", false)
+	errBuf := &bytes.Buffer{}
+	streams.Err = errBuf
+	consumer := &Consumer{
+		Name:          "detail",
+		AcceptedKinds: []Kind{KindMovie},
+		RunOne: func(ctx context.Context, input Envelope) (Envelope, error) {
+			if input.Ref == "b" {
+				return Envelope{}, testError("detail failed")
+			}
+			return New(KindMovie, input.Ref, "id-"+input.Ref), nil
+		},
+	}
+	inputs, err := CollectInputs(bufio.NewReader(strings.NewReader("a\nb\nc\n")), streams, "", []Kind{KindMovie})
+	if err != nil {
+		t.Fatalf("CollectInputs: %v", err)
+	}
+	err = consumer.RunInputs(streams, inputs, OutputText)
+	if err == nil || !strings.Contains(err.Error(), "1 of 3 items failed") {
+		t.Fatalf("expected 1-of-3 failure summary, got %v", err)
+	}
+	// stdout 只有成功项的 ref，不含失败项。
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 2 || lines[0] != "a" || lines[1] != "c" {
+		t.Errorf("stdout = %q, want only a and c", out.String())
+	}
+	// stderr 包含失败原因。
+	if !strings.Contains(errBuf.String(), "detail failed") {
+		t.Errorf("stderr = %q, want 'detail failed'", errBuf.String())
+	}
+}
+
+// TestConsumerHumanModeRenderText OutputHuman 模式下成功项走 RenderText。
+func TestConsumerHumanModeRenderText(t *testing.T) {
+	streams, out := testStreams("", false)
+	renderCalled := false
+	consumer := &Consumer{
+		Name:          "detail",
+		AcceptedKinds: []Kind{KindMovie},
+		RunOne: func(ctx context.Context, input Envelope) (Envelope, error) {
+			return New(KindMovie, input.Ref, "id"), nil
+		},
+		RenderText: func(w io.Writer, envelope Envelope) error {
+			renderCalled = true
+			_, err := fmt.Fprintf(w, ">> %s\n", envelope.Ref)
+			return err
+		},
+	}
+	if err := consumer.RunInputs(streams, []Envelope{New("", "SSIS-589", "")}, OutputHuman); err != nil {
+		t.Fatalf("RunInputs: %v", err)
+	}
+	if !renderCalled {
+		t.Error("OutputHuman must call RenderText for successful items")
+	}
+	if !strings.Contains(out.String(), ">> SSIS-589") {
+		t.Errorf("output = %q, want '>> SSIS-589'", out.String())
+	}
+}

--- a/internal/cli/pipeline/consumer_test.go
+++ b/internal/cli/pipeline/consumer_test.go
@@ -18,6 +18,7 @@ func testStreams(stdin string, terminal bool) (*invocation.Streams, *bytes.Buffe
 	out := &bytes.Buffer{}
 	streams := invocation.NewStreams(strings.NewReader(stdin), out, &bytes.Buffer{})
 	streams.InIsTerminal = terminal
+	streams.OutIsTerminal = terminal
 	return streams, out
 }
 
@@ -233,5 +234,31 @@ func TestConsumerSingleNDJSONEnvelopeStillChecksKind(t *testing.T) {
 	// 默认文本输出使用人类稳定引用（ref）；消费侧（RunOne）保留 id 语义。
 	if strings.TrimSpace(out2.String()) != "SSIS-589" {
 		t.Errorf("text output = %q, want ref SSIS-589", out2.String())
+	}
+}
+
+// TestBatchRunnerTTYStdoutRoutesToLegacy TTY stdout 默认 OutputHuman，单项
+// 纯文本 ref 输入走 legacy 人类文本路径而非 Writer 逐行 ref。
+func TestBatchRunnerTTYStdoutRoutesToLegacy(t *testing.T) {
+	streams, out := testStreams("", true)
+	legacyCalled := false
+	runner := &BatchRunner{
+		Name:  "detail",
+		Kinds: []Kind{KindMovie},
+		RunOne: func(_ *javdb.Client, _ context.Context, input Envelope) (Envelope, error) {
+			return New(KindMovie, input.Ref, "id"), nil
+		},
+		Legacy: func(args []string) error {
+			legacyCalled = true
+			_, err := fmt.Fprintln(out, "human-readable")
+			return err
+		},
+	}
+	// 单项纯文本 ref + TTY stdout → OutputHuman → legacy 路径。
+	if err := runner.ExecuteWithInputs(streams, []Envelope{New("", "SSIS-589", "")}, OutputHuman); err != nil {
+		t.Fatalf("ExecuteWithInputs: %v", err)
+	}
+	if !legacyCalled {
+		t.Error("TTY stdout must route single text input through the legacy human path")
 	}
 }

--- a/internal/cli/pipeline/consumer_test.go
+++ b/internal/cli/pipeline/consumer_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -21,6 +22,57 @@ func testStreams(stdin string, terminal bool) (*invocation.Streams, *bytes.Buffe
 	streams.InIsTerminal = terminal
 	streams.OutIsTerminal = terminal
 	return streams, out
+}
+
+func TestConsumerConcurrencyIsBounded(t *testing.T) {
+	streams, _ := testStreams("", false)
+	inputs := make([]Envelope, 8)
+	for i := range inputs {
+		inputs[i] = New("", fmt.Sprintf("%d", i), "")
+	}
+	var active, maxActive int32
+	consumer := &Consumer{
+		Name:          "test",
+		AcceptedKinds: []Kind{KindMovie},
+		Concurrency:   2,
+		RunOne: func(context.Context, Envelope) (Envelope, error) {
+			current := atomic.AddInt32(&active, 1)
+			for {
+				old := atomic.LoadInt32(&maxActive)
+				if current <= old || atomic.CompareAndSwapInt32(&maxActive, old, current) {
+					break
+				}
+			}
+			time.Sleep(5 * time.Millisecond)
+			atomic.AddInt32(&active, -1)
+			return New(KindMovie, "ok", ""), nil
+		},
+	}
+	if err := consumer.RunInputs(streams, inputs, OutputNDJSON); err != nil {
+		t.Fatalf("RunInputs: %v", err)
+	}
+	if maxActive > 2 {
+		t.Fatalf("max concurrent calls = %d, want <= 2", maxActive)
+	}
+}
+
+func TestConsumerUsesCallContext(t *testing.T) {
+	streams, _ := testStreams("", false)
+	type contextKey string
+	ctx := context.WithValue(context.Background(), contextKey("request"), "active")
+	consumer := &Consumer{
+		Name:    "test",
+		Context: ctx,
+		RunOne: func(ctx context.Context, input Envelope) (Envelope, error) {
+			if got := ctx.Value(contextKey("request")); got != "active" {
+				t.Fatalf("context value = %v, want active", got)
+			}
+			return New(KindMovie, input.Ref, ""), nil
+		},
+	}
+	if err := consumer.RunInputs(streams, []Envelope{New("", "a", "")}, OutputNDJSON); err != nil {
+		t.Fatalf("RunInputs: %v", err)
+	}
 }
 
 func TestCollectInputsMatrix(t *testing.T) {

--- a/internal/cli/pipeline/output.go
+++ b/internal/cli/pipeline/output.go
@@ -15,7 +15,9 @@ type OutputMode int
 const (
 	// OutputAuto 表示尚未解析显式输出 flag。
 	OutputAuto OutputMode = iota
-	// OutputText 强制逐行 ref 文本。
+	// OutputHuman 是 TTY 默认：人类可读文本，由命令的 RenderText 渲染。
+	OutputHuman
+	// OutputText 是非 TTY 默认：稳定记录流，一行一个 ref/URI，便于管道消费。
 	OutputText
 	// OutputNDJSON 强制逐条信封 NDJSON。
 	OutputNDJSON
@@ -23,8 +25,10 @@ const (
 	OutputJSON
 )
 
-// ResolveOutputMode 校验互斥并解析输出模式；未显式指定时保持人类文本。
-func ResolveOutputMode(flagNDJSON, flagJSON bool) (OutputMode, error) {
+// ResolveOutputMode 校验互斥并解析输出模式：显式 --ndjson/--json 优先且互斥；
+// 未显式指定时，TTY stdout 使用人类文本（OutputHuman），非 TTY stdout 使用
+// 稳定记录流（OutputText）。测试可显式设置 OutIsTerminal 来模拟两种场景。
+func ResolveOutputMode(flagNDJSON, flagJSON bool, outIsTerminal bool) (OutputMode, error) {
 	if flagNDJSON && flagJSON {
 		return OutputAuto, errors.New("--ndjson and --json are mutually exclusive")
 	}
@@ -33,6 +37,8 @@ func ResolveOutputMode(flagNDJSON, flagJSON bool) (OutputMode, error) {
 		return OutputNDJSON, nil
 	case flagJSON:
 		return OutputJSON, nil
+	case outIsTerminal:
+		return OutputHuman, nil
 	default:
 		return OutputText, nil
 	}
@@ -64,7 +70,9 @@ func (w *Writer) Mode() OutputMode {
 	return w.mode
 }
 
-// Write 写出一个信封；OutputJSON 模式先缓冲。
+// Write 写出一个信封；OutputJSON 模式先缓冲。OutputHuman 在 Writer 层面
+// 退化为 OutputText（逐行 ref）；命令级别的人类渲染由 Consumer.RenderText
+// 或 Producer.RenderText 负责，在进入 Writer 前已完成分流。
 func (w *Writer) Write(envelope Envelope) error {
 	if w == nil {
 		return nil
@@ -72,7 +80,7 @@ func (w *Writer) Write(envelope Envelope) error {
 	switch w.mode {
 	case OutputNDJSON:
 		return w.ndjson.Encode(envelope)
-	case OutputText:
+	case OutputText, OutputHuman:
 		ref := envelope.Ref
 		if ref == "" {
 			ref = envelope.ID

--- a/internal/cli/pipeline/pipeline_test.go
+++ b/internal/cli/pipeline/pipeline_test.go
@@ -124,19 +124,23 @@ func TestClassifyImageNDJSONText(t *testing.T) {
 
 func TestResolveOutputMode(t *testing.T) {
 	for _, tc := range []struct {
-		name      string
-		ndjson    bool
-		json      bool
-		want      OutputMode
-		wantError bool
+		name          string
+		ndjson        bool
+		json          bool
+		outIsTerminal bool
+		want          OutputMode
+		wantError     bool
 	}{
-		{name: "default", want: OutputText},
-		{name: "explicit ndjson", ndjson: true, want: OutputNDJSON},
-		{name: "explicit json", json: true, want: OutputJSON},
+		{name: "default tty", outIsTerminal: true, want: OutputHuman},
+		{name: "default non-tty", outIsTerminal: false, want: OutputText},
+		{name: "explicit ndjson tty", ndjson: true, outIsTerminal: true, want: OutputNDJSON},
+		{name: "explicit ndjson non-tty", ndjson: true, outIsTerminal: false, want: OutputNDJSON},
+		{name: "explicit json tty", json: true, outIsTerminal: true, want: OutputJSON},
+		{name: "explicit json non-tty", json: true, outIsTerminal: false, want: OutputJSON},
 		{name: "ndjson and json", ndjson: true, json: true, wantError: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			mode, err := ResolveOutputMode(tc.ndjson, tc.json)
+			mode, err := ResolveOutputMode(tc.ndjson, tc.json, tc.outIsTerminal)
 			if tc.wantError {
 				if err == nil {
 					t.Fatal("expected mutual exclusion error")
@@ -147,6 +151,20 @@ func TestResolveOutputMode(t *testing.T) {
 				t.Fatalf("mode = %v err = %v, want %v", mode, err, tc.want)
 			}
 		})
+	}
+}
+
+// TestWriterHumanFallsBackToText Writer 在 OutputHuman 模式下退化为逐行 ref，
+// 与 OutputText 行为一致；命令级人类渲染在进入 Writer 前已分流。
+func TestWriterHumanFallsBackToText(t *testing.T) {
+	envelope := New(KindMovie, "SSIS-589", "9DGB5X")
+	var out bytes.Buffer
+	writer := NewWriter(&out, OutputHuman)
+	if err := writer.Write(envelope); err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(out.String()) != "SSIS-589" {
+		t.Errorf("human fallback output = %q, want SSIS-589", out.String())
 	}
 }
 

--- a/internal/cli/pipeline/producer.go
+++ b/internal/cli/pipeline/producer.go
@@ -52,7 +52,28 @@ func (p *ListProducer) Execute(streams *invocation.Streams, ndjson, json bool) e
 			return err
 		}
 		return jsonxWrite(streams.Out, payload)
-	case OutputText, OutputHuman:
+	case OutputText:
+		if p.ErrNote != nil {
+			p.ErrNote(streams.Err, items)
+		}
+		itemRef := p.ItemRef
+		if itemRef == nil {
+			itemRef = movieItemRef
+		}
+		for _, item := range items {
+			ref, id := itemRef(item)
+			if ref == "" {
+				ref = id
+			}
+			if ref == "" {
+				return fmt.Errorf("%s item has no printable ref or id", p.Name)
+			}
+			if _, err := fmt.Fprintln(streams.Out, ref); err != nil {
+				return err
+			}
+		}
+		return nil
+	case OutputHuman:
 		if p.ErrNote != nil {
 			p.ErrNote(streams.Err, items)
 		}

--- a/internal/cli/pipeline/producer.go
+++ b/internal/cli/pipeline/producer.go
@@ -33,7 +33,7 @@ type ListProducer struct {
 
 // Execute 是 producer 命令 RunE 的通用实现。
 func (p *ListProducer) Execute(streams *invocation.Streams, ndjson, json bool) error {
-	mode, err := ResolveOutputMode(ndjson, json)
+	mode, err := ResolveOutputMode(ndjson, json, streams.OutIsTerminal)
 	if err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func (p *ListProducer) Execute(streams *invocation.Streams, ndjson, json bool) e
 			return err
 		}
 		return jsonxWrite(streams.Out, payload)
-	case OutputText:
+	case OutputText, OutputHuman:
 		if p.ErrNote != nil {
 			p.ErrNote(streams.Err, items)
 		}

--- a/internal/cli/pipeline/runner.go
+++ b/internal/cli/pipeline/runner.go
@@ -28,6 +28,8 @@ type BatchRunner struct {
 	RunMany func(*javdb.Client, context.Context, Envelope) ([]Envelope, error)
 	// Legacy 处理单项既有路径（args 为位置参数列表）。
 	Legacy func(args []string) error
+	// RenderText 是 pipeline 文本/人类模式的领域投影；nil 时输出稳定 ref。
+	RenderText func(io.Writer, Envelope) error
 	// RouteTextThroughPipeline 让单项纯文本输入的非 TTY OutputText 走 Consumer。
 	// 未启用时保留本地/有副作用命令的既有 Legacy 文本语义；需要稳定记录的
 	// 只读命令应显式启用此选项。
@@ -93,6 +95,7 @@ func (b *BatchRunner) ExecuteWithInputs(streams *invocation.Streams, inputs []En
 		Name:          b.Name,
 		AcceptedKinds: b.Kinds,
 		Concurrency:   b.Concurrency,
+		RenderText:    b.RenderText,
 		RunOne: func(ctx context.Context, input Envelope) (Envelope, error) {
 			return b.RunOne(client, ctx, input)
 		},

--- a/internal/cli/pipeline/runner.go
+++ b/internal/cli/pipeline/runner.go
@@ -17,6 +17,8 @@ import (
 //     信封并继续，最终非零；批量显式 --json 输出信封数组。
 type BatchRunner struct {
 	Name string
+	// Context 是本次命令调用的生命周期；未设置时使用 Background。
+	Context context.Context
 	// Kinds 是文本 ref 输入分配的 kind 与消费者接受的 kind。
 	Kinds []Kind
 	// ClientFactory 每次批量执行调用一次，返回携带默认 token 的 client。
@@ -93,6 +95,7 @@ func (b *BatchRunner) ExecuteWithInputs(streams *invocation.Streams, inputs []En
 	}
 	consumer := &Consumer{
 		Name:          b.Name,
+		Context:       b.Context,
 		AcceptedKinds: b.Kinds,
 		Concurrency:   b.Concurrency,
 		RenderText:    b.RenderText,

--- a/internal/cli/pipeline/runner.go
+++ b/internal/cli/pipeline/runner.go
@@ -28,6 +28,10 @@ type BatchRunner struct {
 	RunMany func(*javdb.Client, context.Context, Envelope) ([]Envelope, error)
 	// Legacy 处理单项既有路径（args 为位置参数列表）。
 	Legacy func(args []string) error
+	// RouteTextThroughPipeline 让单项纯文本输入的非 TTY OutputText 走 Consumer。
+	// 未启用时保留本地/有副作用命令的既有 Legacy 文本语义；需要稳定记录的
+	// 只读命令应显式启用此选项。
+	RouteTextThroughPipeline bool
 	// LegacyJSON 表示 Legacy 路径已支持显式 --json 输出（保持既有 shape）。
 	// 为 false 时，单项显式 --json 也走 consumer 路径（RunOne + 信封对象输出），
 	// 避免本地命令（mark/config 等）在 --json 下静默输出裸文本或无输出。
@@ -62,12 +66,14 @@ func (b *BatchRunner) Execute(streams *invocation.Streams, args []string, ndjson
 
 // ExecuteWithInputs 处理已收集的输入（调用方已完成分类）。
 func (b *BatchRunner) ExecuteWithInputs(streams *invocation.Streams, inputs []Envelope, mode OutputMode) error {
-	// 单项 TTY 人类文本/非 TTY 记录文本或显式 --json（且 Legacy 支持 JSON）
+	// 单项 TTY 人类文本或显式 --json（且 Legacy 支持 JSON）
 	// 且输入是纯文本 ref（无 kind）时走既有路径，保持 shape 与认证语义；
+	// 启用 RouteTextThroughPipeline 的只读命令在非 TTY OutputText 下经过
+	// pipeline，输出稳定、可消费的记录；其他命令保留既有 Legacy 文本语义；
 	// NDJSON 信封即使只有一条也必须经过 kind 校验并保留 id 语义，绝不绕过
 	// 消费者检查。Legacy 不支持 JSON 的命令在显式 --json 下走 consumer 路径
 	// 输出信封对象。
-	if len(inputs) == 1 && inputs[0].Kind == "" && (mode == OutputText || mode == OutputHuman || (mode == OutputJSON && b.LegacyJSON)) {
+	if len(inputs) == 1 && inputs[0].Kind == "" && (mode == OutputHuman || (mode == OutputText && !b.RouteTextThroughPipeline) || (mode == OutputJSON && b.LegacyJSON)) {
 		return b.Legacy([]string{pipelineConsumerRef(inputs[0])})
 	}
 	if b.Preflight != nil {

--- a/internal/cli/pipeline/runner.go
+++ b/internal/cli/pipeline/runner.go
@@ -35,6 +35,8 @@ type BatchRunner struct {
 	// Preflight 在批处理路径开始前校验全部输入（如 download 的全量目标展开
 	// 与冲突检查）；返回错误时整个批处理失败，不做任何写入。
 	Preflight func([]Envelope) error
+	// Concurrency 控制批量执行并发度；<= 0 表示串行。
+	Concurrency int
 }
 
 // Execute 是命令 RunE 的通用实现。
@@ -84,6 +86,7 @@ func (b *BatchRunner) ExecuteWithInputs(streams *invocation.Streams, inputs []En
 	consumer := &Consumer{
 		Name:          b.Name,
 		AcceptedKinds: b.Kinds,
+		Concurrency:   b.Concurrency,
 		RunOne: func(ctx context.Context, input Envelope) (Envelope, error) {
 			return b.RunOne(client, ctx, input)
 		},

--- a/internal/cli/pipeline/runner.go
+++ b/internal/cli/pipeline/runner.go
@@ -36,7 +36,7 @@ type BatchRunner struct {
 
 // Execute 是命令 RunE 的通用实现。
 func (b *BatchRunner) Execute(streams *invocation.Streams, args []string, ndjson, json bool) error {
-	mode, err := ResolveOutputMode(ndjson, json)
+	mode, err := ResolveOutputMode(ndjson, json, streams.OutIsTerminal)
 	if err != nil {
 		return err
 	}
@@ -57,11 +57,12 @@ func (b *BatchRunner) Execute(streams *invocation.Streams, args []string, ndjson
 
 // ExecuteWithInputs 处理已收集的输入（调用方已完成分类）。
 func (b *BatchRunner) ExecuteWithInputs(streams *invocation.Streams, inputs []Envelope, mode OutputMode) error {
-	// 单项 TTY 文本或显式 --json（且 Legacy 支持 JSON）且输入是纯文本 ref
-	// （无 kind）时走既有路径，保持 shape 与认证语义；NDJSON 信封即使只有一条
-	// 也必须经过 kind 校验并保留 id 语义，绝不绕过消费者检查。Legacy 不支持
-	// JSON 的命令在显式 --json 下走 consumer 路径输出信封对象。
-	if len(inputs) == 1 && inputs[0].Kind == "" && (mode == OutputText || (mode == OutputJSON && b.LegacyJSON)) {
+	// 单项 TTY 人类文本/非 TTY 记录文本或显式 --json（且 Legacy 支持 JSON）
+	// 且输入是纯文本 ref（无 kind）时走既有路径，保持 shape 与认证语义；
+	// NDJSON 信封即使只有一条也必须经过 kind 校验并保留 id 语义，绝不绕过
+	// 消费者检查。Legacy 不支持 JSON 的命令在显式 --json 下走 consumer 路径
+	// 输出信封对象。
+	if len(inputs) == 1 && inputs[0].Kind == "" && (mode == OutputText || mode == OutputHuman || (mode == OutputJSON && b.LegacyJSON)) {
 		return b.Legacy([]string{pipelineConsumerRef(inputs[0])})
 	}
 	if b.Preflight != nil {
@@ -108,7 +109,7 @@ type Producer struct {
 
 // Execute 是 producer 命令 RunE 的通用实现。
 func (p *Producer) Execute(streams *invocation.Streams, ndjson, json bool) error {
-	mode, err := ResolveOutputMode(ndjson, json)
+	mode, err := ResolveOutputMode(ndjson, json, streams.OutIsTerminal)
 	if err != nil {
 		return err
 	}
@@ -119,7 +120,7 @@ func (p *Producer) Execute(streams *invocation.Streams, ndjson, json bool) error
 	switch mode {
 	case OutputJSON:
 		return p.LegacyJSON(streams.Out)
-	case OutputText:
+	case OutputText, OutputHuman:
 		return p.RenderText(streams.Out, envelopes)
 	default:
 		writer := NewWriter(streams.Out, OutputNDJSON)

--- a/internal/cli/pipeline/runner.go
+++ b/internal/cli/pipeline/runner.go
@@ -23,6 +23,9 @@ type BatchRunner struct {
 	ClientFactory func() (*javdb.Client, error)
 	// RunOne 执行单项并返回输出信封。
 	RunOne func(*javdb.Client, context.Context, Envelope) (Envelope, error)
+	// RunMany 执行单项并返回多个输出信封（fan-out）；设置时优先于 RunOne。
+	// 调用方负责在返回的信封中携带稳定 ref/id。
+	RunMany func(*javdb.Client, context.Context, Envelope) ([]Envelope, error)
 	// Legacy 处理单项既有路径（args 为位置参数列表）。
 	Legacy func(args []string) error
 	// LegacyJSON 表示 Legacy 路径已支持显式 --json 输出（保持既有 shape）。
@@ -84,6 +87,11 @@ func (b *BatchRunner) ExecuteWithInputs(streams *invocation.Streams, inputs []En
 		RunOne: func(ctx context.Context, input Envelope) (Envelope, error) {
 			return b.RunOne(client, ctx, input)
 		},
+	}
+	if b.RunMany != nil {
+		consumer.RunMany = func(ctx context.Context, input Envelope) ([]Envelope, error) {
+			return b.RunMany(client, ctx, input)
+		}
 	}
 	return consumer.RunInputs(streams, inputs, mode)
 }

--- a/internal/cli/pipeline/runner.go
+++ b/internal/cli/pipeline/runner.go
@@ -140,7 +140,14 @@ func (p *Producer) Execute(streams *invocation.Streams, ndjson, json bool) error
 	switch mode {
 	case OutputJSON:
 		return p.LegacyJSON(streams.Out)
-	case OutputText, OutputHuman:
+	case OutputText:
+		for _, envelope := range envelopes {
+			if err := writeRef(streams.Out, envelope); err != nil {
+				return err
+			}
+		}
+		return nil
+	case OutputHuman:
 		return p.RenderText(streams.Out, envelopes)
 	default:
 		writer := NewWriter(streams.Out, OutputNDJSON)

--- a/internal/cli/pipeline/runner.go
+++ b/internal/cli/pipeline/runner.go
@@ -32,6 +32,8 @@ type BatchRunner struct {
 	Legacy func(args []string) error
 	// RenderText 是 pipeline 文本/人类模式的领域投影；nil 时输出稳定 ref。
 	RenderText func(io.Writer, Envelope) error
+	// RenderError 是 pipeline 文本/人类模式的错误投影；nil 使用 Name 前缀。
+	RenderError func(io.Writer, error) error
 	// RouteTextThroughPipeline 让单项纯文本输入的非 TTY OutputText 走 Consumer。
 	// 未启用时保留本地/有副作用命令的既有 Legacy 文本语义；需要稳定记录的
 	// 只读命令应显式启用此选项。
@@ -99,6 +101,7 @@ func (b *BatchRunner) ExecuteWithInputs(streams *invocation.Streams, inputs []En
 		AcceptedKinds: b.Kinds,
 		Concurrency:   b.Concurrency,
 		RenderText:    b.RenderText,
+		RenderError:   b.RenderError,
 		RunOne: func(ctx context.Context, input Envelope) (Envelope, error) {
 			return b.RunOne(client, ctx, input)
 		},

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -51,6 +51,10 @@ func New(stdin io.Reader, stdout, stderr io.Writer) *cobra.Command {
 	if file, ok := stdin.(*os.File); ok && term.IsTerminal(int(file.Fd())) {
 		streams.InIsTerminal = true
 	}
+	// 非 TTY stdout 是管道/记录输出信号；探测只在 stdout 是真实终端时生效。
+	if file, ok := stdout.(*os.File); ok && term.IsTerminal(int(file.Fd())) {
+		streams.OutIsTerminal = true
+	}
 	command := &cobra.Command{
 		Use:           "javdb",
 		Short:         "JavDB app API command-line client",

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -128,12 +128,16 @@ Usage:
   javdb search KEYWORD|IMAGE [flags]
 
 Flags:
+      --cnsub              Only magnets with Chinese subtitles (requires --magnets)
       --filter-by string   can_play|magnets|subtitle|single
       --has-magnets        Drop movie rows with magnets_count == 0
+      --hd                 Only HD magnets (requires --magnets)
   -h, --help               help for search
       --image              Treat the argument as an image path or HTTP(S) URL
       --json               Machine-readable JSON
       --limit int          Page size (0 = server default)
+      --magnets int        Fetch magnets for each result: 0=all, N=top N by best rule
+      --min-size string    Min magnet size e.g. 2000, 4GB, 500MB (requires --magnets)
       --ndjson             Pipeline NDJSON envelopes
       --no-cache           Bypass the reverse-search response cache
       --page int           Page number (default 1)

--- a/internal/javdb/appapi/client.go
+++ b/internal/javdb/appapi/client.go
@@ -177,6 +177,9 @@ func PickBestMagnet(items []map[string]any) map[string]any {
 // MagnetURI 从磁力记录构建 magnet URI。
 func MagnetURI(item map[string]any) string { return magnets.MagnetURI(item) }
 
+// MagnetBetter 报告磁力 a 是否优于 b（cnsub > hd > size > files_count）。
+func MagnetBetter(a, b map[string]any) bool { return magnets.MagnetBetter(a, b) }
+
 // LoadOrCreateDeviceUUID 读取或创建稳定 device UUID。
 func LoadOrCreateDeviceUUID(path string) (string, error) {
 	return transport.LoadOrCreateDeviceUUID(path)

--- a/internal/javdb/appapi/client_test.go
+++ b/internal/javdb/appapi/client_test.go
@@ -54,6 +54,7 @@ var (
 	_ func(*Client, string) ([]map[string]any, error)                                   = (*Client).MovieMagnets
 	_ func(*Client, string, int, int) ([]map[string]any, error)                         = (*Client).MovieComments
 	_ func(*Client, string) (string, error)                                             = (*Client).ResolveMovieID
+	_ func(a, b map[string]any) bool                                                    = MagnetBetter
 	_ func(*Client, string, string) (int64, error)                                      = (*Client).DownloadImage
 	_ func(*Client, string, string) (int64, error)                                      = (*Client).DownloadHLS
 	_ func(*Client, string, string) (SearchResult, error)                               = (*Client).RankingsMovies

--- a/internal/javdb/appapi/endpoint/magnets/magnets.go
+++ b/internal/javdb/appapi/endpoint/magnets/magnets.go
@@ -27,14 +27,14 @@ func PickBestMagnet(magnets []map[string]any) map[string]any {
 	}
 	best := magnets[0]
 	for _, m := range magnets[1:] {
-		if magnetBetter(m, best) {
+		if MagnetBetter(m, best) {
 			best = m
 		}
 	}
 	return best
 }
 
-func magnetBetter(a, b map[string]any) bool {
+func MagnetBetter(a, b map[string]any) bool {
 	ac, bc := boolScore(a["cnsub"]), boolScore(b["cnsub"])
 	if ac != bc {
 		return ac > bc

--- a/sdk/contract_external_test.go
+++ b/sdk/contract_external_test.go
@@ -31,6 +31,7 @@ var (
 	_ func(path string) (string, error)                                      = javdb.LoadOrCreateDeviceUUID
 	_ func(items []map[string]any, cnsub, hd bool, min int) []map[string]any = javdb.FilterMagnets
 	_ func(items []map[string]any) map[string]any                            = javdb.PickBestMagnet
+	_ func(items []map[string]any, count int) []map[string]any               = javdb.RankMagnets
 	_ func(m map[string]any) string                                          = javdb.MagnetURI
 	_ func(period string) string                                             = javdb.RankingPeriod
 	_ func(period string) string                                             = javdb.ActorPeriod
@@ -149,6 +150,31 @@ func TestExternalMagnetHelpersPureBehavior(t *testing.T) {
 	}
 	if got := javdb.MagnetURI(best); got != "magnet:?xt=urn:btih:AAA" {
 		t.Fatalf("MagnetURI = %q", got)
+	}
+}
+
+func TestExternalRankMagnetsStableSortAndTruncate(t *testing.T) {
+	items := []map[string]any{
+		{"name": "small", "size": float64(64), "hash": "BBB"},
+		{"name": "big", "size": float64(4096), "cnsub": true, "hash": "AAA"},
+		{"name": "mid", "size": float64(512), "hd": true, "hash": "CCC"},
+	}
+	// N=0: 全部排序，cnsub 优先 → big, hd 次之 → mid, 最后 small。
+	all := javdb.RankMagnets(items, 0)
+	if len(all) != 3 {
+		t.Fatalf("RankMagnets(0) len = %d, want 3", len(all))
+	}
+	if all[0]["hash"] != "AAA" || all[1]["hash"] != "CCC" || all[2]["hash"] != "BBB" {
+		t.Fatalf("RankMagnets(0) order = %+v", all)
+	}
+	// N=1: 截取第一个。
+	one := javdb.RankMagnets(items, 1)
+	if len(one) != 1 || one[0]["hash"] != "AAA" {
+		t.Fatalf("RankMagnets(1) = %+v, want [AAA]", one)
+	}
+	// 不修改输入。
+	if items[0]["name"] != "small" {
+		t.Fatal("input slice was modified")
 	}
 }
 

--- a/sdk/magnets.go
+++ b/sdk/magnets.go
@@ -1,6 +1,10 @@
 package javdb
 
-import "github.com/FlanChanXwO/javdb-cli/internal/javdb/appapi"
+import (
+	"sort"
+
+	"github.com/FlanChanXwO/javdb-cli/internal/javdb/appapi"
+)
 
 // Re-export magnet helpers for SDK callers.
 func FilterMagnets(magnets []map[string]any, cnsub, hd bool, minSize int) []map[string]any {
@@ -13,4 +17,22 @@ func PickBestMagnet(magnets []map[string]any) map[string]any {
 
 func MagnetURI(m map[string]any) string {
 	return appapi.MagnetURI(m)
+}
+
+// RankMagnets 按优先规则（cnsub > hd > size > files_count）稳定排序磁力列表
+// 并按 count 截取。count <= 0 返回全部排序结果；count > 0 返回前 count 项。
+// 不修改输入切片。
+func RankMagnets(magnets []map[string]any, count int) []map[string]any {
+	if len(magnets) == 0 {
+		return magnets
+	}
+	ranked := make([]map[string]any, len(magnets))
+	copy(ranked, magnets)
+	sort.SliceStable(ranked, func(i, j int) bool {
+		return appapi.MagnetBetter(ranked[i], ranked[j])
+	})
+	if count > 0 && count < len(ranked) {
+		ranked = ranked[:count]
+	}
+	return ranked
 }

--- a/sdk/reversesearch.go
+++ b/sdk/reversesearch.go
@@ -69,9 +69,13 @@ type ReverseSearchOptions struct {
 	RequestTimeout time.Duration
 }
 
-// ImageSearchOptions 控制候选到 JavDB 的联动解析；当前固定严格精确匹配，
-// 保留该类型以便未来扩展（并发数、解析重试等）。
-type ImageSearchOptions struct{}
+// ImageSearchOptions 控制候选到 JavDB 的联动解析。
+type ImageSearchOptions struct {
+	// SkipMovieDetail 为 true 时只做严格番号 → ID 解析，跳过完整详情请求。
+	// 用于纯 ref/磁力路径：magnets 只需要 movie ID 即可获取磁力列表，不需要
+	// 完整详情。默认 false 保持现有行为（解析 ID + 完整详情）。
+	SkipMovieDetail bool
+}
 
 // ImageSearchError 是单候选联动失败的稳定错误。
 type ImageSearchError struct {
@@ -162,10 +166,11 @@ func (c *Client) ReverseSearch(ctx context.Context, request ReverseSearchRequest
 	return normalized, nil
 }
 
-// SearchByImage 反搜并对全部候选并发执行严格番号解析与完整详情；结果按
-// provider 原始顺序恢复。候选级失败写入 ImageSearchMatch.Error 并继续，
-// provider 顶层失败直接返回 error。
-func (c *Client) SearchByImage(ctx context.Context, request ReverseSearchRequest, _ ImageSearchOptions) (ImageSearchResult, error) {
+// SearchByImage 反搜并对全部候选并发执行严格番号解析与（可选）完整详情；
+// 结果按 provider 原始顺序恢复。候选级失败写入 ImageSearchMatch.Error 并继续，
+// provider 顶层失败直接返回 error。opts.SkipMovieDetail 为 true 时跳过完整详情
+// 请求，仅保留 movie ID（用于纯 ref/磁力路径）。
+func (c *Client) SearchByImage(ctx context.Context, request ReverseSearchRequest, opts ImageSearchOptions) (ImageSearchResult, error) {
 	response, err := c.ReverseSearch(ctx, request)
 	if err != nil {
 		return ImageSearchResult{}, err
@@ -187,14 +192,17 @@ func (c *Client) SearchByImage(ctx context.Context, request ReverseSearchRequest
 				matches[index] = match
 				return
 			}
-			movie, err := c.MovieDetail(ctx, movieID)
-			if err != nil {
-				match.Error = &ImageSearchError{Stage: "link", Code: "detail", Message: err.Error()}
-				match.MovieID = movieID
+			match.MovieID = movieID
+			if opts.SkipMovieDetail {
 				matches[index] = match
 				return
 			}
-			match.MovieID = movieID
+			movie, err := c.MovieDetail(ctx, movieID)
+			if err != nil {
+				match.Error = &ImageSearchError{Stage: "link", Code: "detail", Message: err.Error()}
+				matches[index] = match
+				return
+			}
 			match.Movie = movie
 			matches[index] = match
 		}(index, candidate)

--- a/sdk/reversesearch_test.go
+++ b/sdk/reversesearch_test.go
@@ -233,6 +233,46 @@ func TestSearchByImagePartialFailureKeepsOrder(t *testing.T) {
 	}
 }
 
+// TestSearchByImageSkipMovieDetail SkipMovieDetail=true 时仅做番号→ID 解析，
+// 不请求完整详情；Match.MovieID 有值，Match.Movie 为 nil。
+func TestSearchByImageSkipMovieDetail(t *testing.T) {
+	provider := providerServer(t, `{"results":[
+		{"video_code":"SSIS-589","best_similarity":95.2,"frames":[]}]}`)
+	defer provider.Close()
+
+	javdbServer := javdbServer(t,
+		[]map[string]any{{"number": "SSIS-589", "id": "id-a"}},
+		map[string]map[string]any{"id-a": {"number": "SSIS-589"}},
+	)
+	defer javdbServer.Close()
+
+	client, err := javdb.New(javdb.WithHost(javdbServer.URL), javdb.WithReverseSearch(javdb.ReverseSearchOptions{Retries: 1}))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	result, err := client.SearchByImage(context.Background(), javdb.ReverseSearchRequest{
+		Image:    testJPEG,
+		Filename: "frame.jpg",
+		Source:   javdb.ReverseSearchSource{Name: "test", URL: provider.URL},
+	}, javdb.ImageSearchOptions{SkipMovieDetail: true})
+	if err != nil {
+		t.Fatalf("SearchByImage: %v", err)
+	}
+	if len(result.Matches) != 1 {
+		t.Fatalf("matches = %d, want 1", len(result.Matches))
+	}
+	match := result.Matches[0]
+	if match.Error != nil {
+		t.Fatalf("unexpected error: %v", match.Error)
+	}
+	if match.MovieID != "id-a" {
+		t.Errorf("MovieID = %q, want id-a", match.MovieID)
+	}
+	if match.Movie != nil {
+		t.Errorf("Movie should be nil when SkipMovieDetail is true, got %+v", match.Movie)
+	}
+}
+
 func TestResolveMovieIDExactCaseInsensitive(t *testing.T) {
 	javdbServer := javdbServer(t,
 		[]map[string]any{{"number": "midv-854", "id": "id-c"}},

--- a/skills/javdb-cli/SKILL.md
+++ b/skills/javdb-cli/SKILL.md
@@ -121,10 +121,14 @@ javdb unmark SSIS-589
    "无结果"。
 2. 反搜缓存：默认启用（30 天，按 source + 原图 SHA-256）。`javdb cache reverse-search
    [--source NAME] [--clear]` 只清理反搜缓存；`--no-cache` 按次绕过。
-3. 管道：多数命令接受非 TTY stdin 批处理并默认输出文本；显式 `--ndjson` 才输出
+3. 管道：多数命令接受非 TTY stdin 批处理，TTY stdout 默认输出人类文本，非 TTY
+   stdout 默认输出稳定记录流（逐行 ref/URI）；显式 `--ndjson` 才输出
    `javdb.pipeline/v1` NDJSON 信封（`--ndjson`/`--json` 互斥）。例如
    `javdb search SSIS --ndjson | javdb detail`。位置参数与非空 stdin 同时出现是歧义错误。
    `auth login`、`config set` 与密码提示不使用管道 stdin。
+4. 一体化磁力搜索：`javdb search KEYWORD --magnets N` 一次完成搜索、筛选、排序和
+   磁力获取。`--cnsub`、`--hd`、`--min-size` 在排序前筛选；`N=0` 返回全部，`N>0`
+   取前 N。文本模式输出磁力 URI，NDJSON 输出 `kind=magnet` 信封。仅支持 movie 搜索。
 
 ## 路由
 


### PR DESCRIPTION
## Summary / 概述

Prepare the v0.7.2 bilingual release notes for the pipeline, search, magnet, and producer output fixes.

准备 v0.7.2 双语发布说明，覆盖管道、搜索、磁力和 producer 输出修复。

## Scope and compatibility / 范围与兼容性

- CLI output contract: non-TTY `OutputText` producers emit one stable `ref`/`id` per line; TTY keeps human rendering.
- `search --magnets`, reverse-image magnet lookup, and pipeline error propagation are covered.
- No public SDK, configuration, authentication, environment-variable, or migration changes.

- CLI 输出契约：非 TTY `OutputText` producer 每行输出一个稳定 `ref`/`id`，TTY 保留人类渲染。
- 覆盖 `search --magnets`、以图搜磁力和管道错误透传。
- 没有 public SDK、配置、认证、环境变量或迁移变更。

## Verification / 验证

```text
pre-commit run --all-files: passed
go test ./...: passed
sh scripts/build.sh: passed
go run ./scripts/releasenotes validate --version 0.7.2 --previous v0.7.1 --dir changelog/v0.7.2 --audit /tmp/javdb-release-audit-v0.7.2.json: passed locally
JAVDB_BIN=./build/javdb bash e2e/run.sh: pass=17 fail=0 skip=1
```

真实 JavDB App API 已运行匿名只读覆盖；认证命令因本机未提供 `JAVDB_E2E_USERNAME/PASSWORD` 而跳过。E2E 未输出账号、token 或私有响应。

## Release note declaration / Release note 声明

<!-- release-note
category: Documentation
breaking: false
summary: Prepare the bilingual v0.7.2 release notes and align real API smoke assertions with stable non-TTY records.
none_reason:
-->

## Checklist / 检查清单

- [x] The change is focused and linked to an issue when appropriate. / 改动目标明确，并在适用时关联 Issue。
- [x] I added or updated focused tests for changed behavior. / 我已为变更行为新增或更新聚焦测试。
- [x] I ran the relevant tests and recorded the results above. / 我已运行相关测试并在上方记录结果。
- [x] I updated the required CLI reference, SDK, README, maintainer, and operator-skill documentation. / 我已更新所需的 CLI reference、SDK、README、维护者和 operator-skill 文档。
- [x] I completed the required release-note declaration above; `None` has a concrete reason when selected. / 我已填写上方必需的 release-note 声明；选择 `None` 时已提供理由。
- [x] I documented every new timeout, retry, pagination or result limit, truncation, fallback, or downgrade and its evidence. / 我已记录每项新增限制、回退或降级及其证据。
- [x] I did not add passwords, JWTs, `~/.javdb-cli/auth.json` contents, proxy credentials, private URLs, local state, or private API responses. / 我没有添加密码、JWT、认证文件内容、代理凭据、私有 URL、本地状态或私有 API 响应。
- [x] I updated migration guidance for every breaking change. / 我已为每个破坏性变更更新迁移指引。

## Summary by Sourcery

准备 v0.7.2 版本说明，并更新 CLI、pipeline、magnets 以及反向图片搜索行为，以在非 TTY 环境下提供稳定的输出记录和磁力链接（magnet）查找路径。

New Features:
- 新增 `search --magnets` 指令，支持过滤和排序后的磁力结果，包括在 text、JSON 和 NDJSON 输出模式下的反向图片磁力查找。
- 允许 search 和 pipeline 的消费者将电影和命名实体结果扩散（fan out）为按实体划分的封装（envelopes），并为下游命令提供稳定的引用（stable refs）。
- 在 SDK 中暴露 `RankMagnets` 辅助工具，并支持 `SkipMovieDetail` 图片搜索选项，以满足仅磁力链接的工作流需求。

Bug Fixes:
- 确保非 TTY 的 producer 和 pipeline 文本输出使用稳定的引用或 URI，而非面向人的表格，并在不重新处理的情况下保留错误封装（error envelopes）。
- 修复 magnets 和 search pipeline，避免重复的电影详情请求，正确向下游传播上游错误，并报告部分磁力失败和写入错误。
- 对齐 magnets 和 search 命令，使 NDJSON 和 JSON 输出使用一致的磁力封装，并在并发处理时保持输入顺序。

Enhancements:
- 引入感知 TTY 的输出模式解析，在终端默认使用人类可读的文本，在非 TTY 的 stdout 上默认使用稳定记录流。
- 扩展 pipeline 的 Consumer 和 `BatchRunner`，增加 fan-out、并发控制以及人类/文本渲染钩子，以支持更健壮的批处理契约。
- 优化反向图片搜索行为，将机器可读记录与面向人的诊断信息分离，把稳定引用路由到 stdout，把详细输出路由到 stderr。

Documentation:
- 更新中英文 CLI 和 SDK 参考文档、维护者架构笔记、技能指南以及 README，说明新的磁力搜索、pipeline 以及感知 TTY 的输出契约。
- 添加双语 v0.7.2 版本说明和更新日志条目，记录 pipeline fan-out、magnets 集成以及非 TTY 输出稳定性。

Tests:
- 添加针对 magnets、search、pipeline 消费者/生产者行为、反向图片磁力流程以及在 text 和 NDJSON 模式下排名/浏览/tags 输出的聚焦单元测试和集成测试。
- 加强外部 SDK 契约测试，覆盖磁力排序、反向图片搜索选项和应用 API 辅助工具，并扩展端到端（e2e）测试范围，验证稳定记录输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prepare v0.7.2 release notes and update CLI, pipeline, magnets, and reverse-image search behavior for stable non-TTY output records and magnet lookup paths.

New Features:
- Add search --magnets with filters and ranked magnet results, including reverse-image magnet lookup across text, JSON, and NDJSON output modes.
- Enable search and pipeline consumers to fan out movie and named-entity results into per-entity envelopes and stable refs for downstream commands.
- Expose a RankMagnets helper in the SDK and support SkipMovieDetail image search options for magnet-only workflows.

Bug Fixes:
- Ensure non-TTY producer and pipeline text outputs emit stable refs or URIs instead of human tables, and preserve error envelopes without reprocessing.
- Fix magnets and search pipelines to avoid redundant movie detail requests, correctly propagate upstream errors, and report partial magnet failures and write errors.
- Align magnets and search commands so NDJSON and JSON outputs use consistent magnet envelopes and keep input ordering under concurrent processing.

Enhancements:
- Introduce TTY-aware output mode resolution that defaults to human-readable text on terminals and stable record streams on non-TTY stdout.
- Extend pipeline Consumer and BatchRunner with fan-out, concurrency, and human/text rendering hooks to support robust batch processing contracts.
- Refine reverse-image search behavior to separate machine-readable records from human diagnostics, routing stable refs to stdout and detailed output to stderr.

Documentation:
- Update English and Chinese CLI and SDK reference documentation, maintainer architecture notes, skills guide, and README to describe the new magnet search, pipeline, and TTY-aware output contracts.
- Add bilingual v0.7.2 release notes and changelog entries documenting pipeline fan-out, magnets integration, and non-TTY output stability.

Tests:
- Add focused unit and integration tests for magnets, search, pipeline consumer/producer behavior, reverse-image magnet flow, and rankings/browse/tags output across text and NDJSON modes.
- Strengthen external SDK contract tests around magnet ranking, reverse-image search options, and app API helpers, and extend e2e coverage for stable record outputs.

</details>