### PR TITLE
fix(release): resolve squash merge note sources

### DIFF
--- a/.agents/skills/javdb-cli-commit-message/SKILL.md
+++ b/.agents/skills/javdb-cli-commit-message/SKILL.md
@@ -21,3 +21,4 @@ git log --oneline -10
 - 使用 Conventional Commits，并贴近近期风格：`feat`、`fix`、`docs`、`refactor`、`test`、`chore`、`ci`。
 - subject 使用英文、小写开头，约 72 字符；不写 `misc`、`update files` 或 `wip`。
 - 行为修复用 `fix`；包边界或内部结构用 `refactor`；文档和 agent 文件用 `docs`；测试用 `test`；构建、脚本、依赖与 workflow 用 `chore` 或 `ci`。
+- 生成信息只描述 staged diff，不代替提交前门禁；提交前按改动范围运行 `pre-commit`、聚焦测试和项目规定的构建/文档检查，并确认工作区没有把无关改动一并提交。

--- a/.agents/skills/javdb-cli-docs/SKILL.md
+++ b/.agents/skills/javdb-cli-docs/SKILL.md
@@ -13,8 +13,9 @@ description: Maintain javdb-cli documentation; locale and maintainer routing liv
 1. 读取文档规范，确定内容应落在 locale、maintainer 文档、`changelog/` 或产品 skill。
 2. 按目标 locale 写作；命令、路径、包名和 code-id 保持英文。
 3. 修改已翻译的 public contract 时保持行为语义对应；允许自然调整句式，不得让不同语言出现不同契约。
-4. 发布说明只写入 `changelog/`：功能 PR 填 release-note metadata，release-prep PR 才更新版本化双语 notes。
-5. 同一规则只写一处，其他位置使用链接路由；完成后检查链接、locale 导航和 `git diff --check`。
+4. 发布说明只写入 `changelog/`：功能 PR 填 `.github/PULL_REQUEST_TEMPLATE.md` 中的四个 `release-note` 字段，使用 `go run ./scripts/releasenotes pr-validate --event EVENT_JSON` 校验；release-prep PR 才更新版本化双语 notes。
+5. 构建、发布、workflow 或 CI 门禁文档变化时，同步检查 `docs/maintainers/development.md`、相关 workflow 测试和 README 安装/发布说明；不要只更新用户 locale 文档。
+6. 同一规则只写一处，其他位置使用链接路由；完成后检查链接、locale 导航、`git diff --check` 和 `sh scripts/test-documentation.sh`。
 
 ## 约束
 

--- a/.agents/skills/javdb-cli-release-notes/SKILL.md
+++ b/.agents/skills/javdb-cli-release-notes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: javdb-cli-release-notes
-description: Manage javdb-cli PR release-note metadata, bilingual release-prep notes, historical GitHub Release synchronization, and approved version releases.
+description: Manage javdb-cli PR release-note metadata, bilingual release-prep notes, squash-merge source attribution, historical GitHub Release synchronization, and approved version releases. Use this whenever a user mentions release notes, release-prep, merge, tag, GitHub Release, CI release checks, or a release retry.
 ---
 
 # javdb-cli release notes and release workflow
@@ -23,14 +23,21 @@ description 或执行 `sync-history --apply` 前，必须在当前会话取得�
 
 ## Release-prep
 
-1. 审计候选范围：
+1. 先确定发布边界：上一稳定 tag、最终要发布的 `main` commit，以及本次 release-prep PR 自身的 PR URL。不要用脏工作区、未合并 branch tip 或猜测的 PR 号作为最终来源。
+
+2. 在 release-prep PR 合并后、创建 tag 前，对最终 `main` commit 做一次精确审计：
 
    ```bash
-   go run ./scripts/releasenotes audit --repo FlanChanXwO/javdb-cli --from vPREVIOUS --to COMMIT_OR_TAG --output /tmp/javdb-release-audit.json
+   go run ./scripts/releasenotes audit --repo FlanChanXwO/javdb-cli --from vPREVIOUS --to FINAL_MAIN_COMMIT --output /tmp/javdb-release-audit.json
+   go run ./scripts/releasenotes validate --version X.Y.Z --previous vPREVIOUS --dir changelog/vX.Y.Z --audit /tmp/javdb-release-audit.json
    ```
 
-2. 提出版本、范围、breaking assessment 与双语条目；等待明确授权。
-3. 在 `changelog/plans/vX.Y.Z.json` 维护审核后的双语计划，并先预览、再显式写入：
+   只有 audit report 的 PR/commit 来源集合与 release plan、双语 notes 完全一致时才能继续。审计失败、GitHub API 来源查询失败或出现未归因 direct commit 时停止，不创建 tag。
+
+   GitHub 的 squash merge 可能不会让 `/commits/{sha}/pulls` 返回 PR。审计工具只接受提交标题末尾的 GitHub `(#N)` 后缀，并再次确认该 PR 的 `merge_commit_sha` 精确等于提交 SHA；不能靠标题猜测或手工伪造来源。
+
+3. 提出版本、范围、breaking assessment 与双语条目；等待明确授权。
+4. 在 `changelog/plans/vX.Y.Z.json` 维护审核后的双语计划，并先预览、再显式写入：
 
    ```bash
    go run ./scripts/releasenotes prepare --version X.Y.Z --previous vPREVIOUS --date YYYY-MM-DD --plan changelog/plans/vX.Y.Z.json
@@ -38,10 +45,12 @@ description 或执行 `sync-history --apply` 前，必须在当前会话取得�
    go run ./scripts/releasenotes validate --version X.Y.Z --previous vPREVIOUS --dir changelog/vX.Y.Z
    ```
 
-4. 创建 release-prep PR，运行本地门禁并等待 required CI/review。tag 只能指向已合并的 release-prep commit。
+5. 创建 release-prep PR。PR 自身的 `release-note` 声明和 PR URL 也必须进入该版本 plan；如 PR 编号只能在创建后确定，先创建 PR，再补齐 plan/双语 notes 并等待 required CI/review。tag 只能指向已合并且已通过最终审计的 release-prep commit。
 
 ## 历史同步与发布
 
-对每个历史版本先 dry-run，再在授权后加 `--apply`。发布后读取 GitHub Release 正文，确认它与本地
-双语渲染一致。网络、GitHub API、格式或来源验证失败必须直接报告；不得伪造成功、猜测 PR 号或静默
-改写其他 Release。本机联网调用显式从 `GH_TOKEN` 读取凭据；不要打印、提交或把令牌写入计划文件。
+对每个历史版本先 dry-run，再在授权后加 `--apply`。创建/推送 tag 前再次确认远端不存在同名 tag；已推送的
+稳定 tag 视为不可变，失败时不得删除、覆盖或创建替代 tag，除非用户明确授权该破坏性修复并说明影响。
+发布后读取 GitHub Release 正文、tag target、draft 状态和全部资产，确认它与本地双语渲染一致。网络、
+GitHub API、格式或来源验证失败必须直接报告；不得伪造成功、猜测 PR 号或静默改写其他 Release。本机
+联网调用显式从 `GH_TOKEN` 读取凭据；不要打印、提交或把令牌写入计划文件。

--- a/.agents/skills/javdb-cli-review/SKILL.md
+++ b/.agents/skills/javdb-cli-review/SKILL.md
@@ -9,9 +9,10 @@ description: Review javdb-cli changes with finding-first output; review criteria
 
 ## 流程
 
-1. 收集范围：`git status --short` 和 `git diff`，或用户指定的 commit/PR 范围。
+1. 收集范围：若目标是 PR，先用 `gh pr view NUMBER --json baseRefName,headRefName,baseRefOid,headRefOid,state,isDraft,mergeable,mergeStateStatus,statusCheckRollup,reviewDecision,body,url` 和 `gh pr diff NUMBER` 固定远端 base/head SHA；不要让脏工作区的 `git diff` 替代 PR diff。只有用户明确要审查本地改动时才使用 `git status --short`/`git diff`。
 2. 读取 review checklist，按架构边界、行为风险、CLI/SDK 契约、凭据与发布、测试的顺序核对。
-3. 每个 finding 落到具体文件和行号；无法确认的事项列为 Open Questions，不猜测。
+3. PR 范围还要检查模板中的 release-note 四字段、required CI、mergeability、review/approval 状态、目标分支保护和是否存在 bypass 依赖；这些属于发布前置条件，不是代码 finding。
+4. 每个代码 finding 落到具体文件和行号；CI、PR 状态或策略问题用对应的 URL、job/check 名称和 SHA 定位；无法确认的事项列为 Open Questions，不猜测。
 
 ## 输出
 

--- a/changelog/plans/v0.7.2.json
+++ b/changelog/plans/v0.7.2.json
@@ -20,6 +20,15 @@
       "sources": [
         "https://github.com/FlanChanXwO/javdb-cli/pull/29"
       ]
+    },
+    {
+      "category": "Maintenance",
+      "breaking": false,
+      "english": "Make release-note audit resolve squash-merged PRs by verifying the exact merge commit, and document the post-merge release preflight across project skills and maintainer guidance.",
+      "zh_cn": "让 release-note 审计通过核对精确 merge commit 识别 squash merge 的 PR，并在 project skills 和维护者文档中补充合并后的发布前置流程。",
+      "sources": [
+        "https://github.com/FlanChanXwO/javdb-cli/pull/30"
+      ]
     }
   ],
   "new_contributors": []

--- a/changelog/v0.7.2/en.md
+++ b/changelog/v0.7.2/en.md
@@ -8,4 +8,8 @@
 
 - Make non-TTY producer output consumable as stable refs, preserve upstream error envelopes, avoid redundant movie detail requests, report partial magnet and output failures correctly, and align real API smoke checks with the output contract. ([#29](https://github.com/FlanChanXwO/javdb-cli/pull/29))
 
+## Maintenance
+
+- Make release-note audit resolve squash-merged PRs by verifying the exact merge commit, and document the post-merge release preflight across project skills and maintainer guidance. ([#30](https://github.com/FlanChanXwO/javdb-cli/pull/30))
+
 **Full Changelog**: [v0.7.1...v0.7.2](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.1...v0.7.2)

--- a/changelog/v0.7.2/zh-CN.md
+++ b/changelog/v0.7.2/zh-CN.md
@@ -8,4 +8,8 @@
 
 - 修复非 TTY producer 输出不可稳定消费、上游错误信封被重复处理、重复影片详情请求，以及部分磁力和输出失败未正确报告的问题，并让真实 API 冒烟检查与输出契约一致。 ([#29](https://github.com/FlanChanXwO/javdb-cli/pull/29))
 
+## 维护
+
+- 让 release-note 审计通过核对精确 merge commit 识别 squash merge 的 PR，并在 project skills 和维护者文档中补充合并后的发布前置流程。 ([#30](https://github.com/FlanChanXwO/javdb-cli/pull/30))
+
 **完整变更**：[v0.7.1...v0.7.2](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.1...v0.7.2)

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -122,6 +122,12 @@ sh scripts/test-releasenotes.sh
 检查或 dry-run；`prepare --apply` 会写入本地 changelog，`sync-history --apply` 会修改
 GitHub Release 正文。后两者不是默认回归，不得在测试中使用真实仓库凭据或隐式写入。
 
+release-prep PR 合并后，必须以最终 `main` commit 重新运行 `audit`，再用同一份报告运行
+`validate --audit`，并确认报告来源集合与版本 plan、双语 notes 完全一致后才能创建 tag。Squash
+merge 的最终 commit 可能没有 GitHub 的直接 PR 关联；审计工具只在提交标题带有 GitHub 生成的
+`(#N)` 后缀且对应 PR 的 `merge_commit_sha` 精确匹配时回溯该 PR，不能猜测 PR 号或把未确认的
+commit 写入 notes。
+
 ## 构建、打包与平台
 
 Release 只支持六个原生目标：`darwin/amd64`、`darwin/arm64`、`linux/amd64`、
@@ -207,7 +213,8 @@ environment，同时继续公开 `version --json` 并发布兼容 `checksums.txt
    上用同名 checks 显式确认原生 smoke 被跳过。`Platform smoke gate` 始终汇总并要求矩阵成功。
 3. feature PR 只填写 `.github/PULL_REQUEST_TEMPLATE.md` 中唯一的 release-note declaration；不要
    编辑 `changelog/unreleased/`。release-prep PR 将审核后的双语计划放入
-   `changelog/plans/vX.Y.Z.json`，然后运行 `prepare` 与 `validate` 生成版本目录。
+   `changelog/plans/vX.Y.Z.json`，并在 PR 编号确定后将自身 PR URL 纳入 plan，然后运行 `prepare`
+   与 `validate` 生成版本目录。
 4. `vX.Y.Z` tag 必须不可变且可追溯到 `main`；Release workflow 在打包前校验版本化双语 notes、
    审计来源，并以同一渲染正文创建 GitHub Release。
 5. `publish` job 绑定受保护的 `release` environment，从 `JAVDB_RELEASE_ED25519_PRIVATE_KEYS`

--- a/scripts/internal/releasenotes/audit/audit.go
+++ b/scripts/internal/releasenotes/audit/audit.go
@@ -11,7 +11,9 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/FlanChanXwO/javdb-cli/scripts/internal/releasenotes/document"
@@ -26,6 +28,8 @@ type Config struct {
 	To         string
 	Client     github.Client
 }
+
+var squashPullRequestPattern = regexp.MustCompile(`\(#([1-9][0-9]*)\)\s*$`)
 
 // Run 执行 audit 子命令。
 func Run(arguments []string) error {
@@ -119,15 +123,15 @@ func Collect(ctx context.Context, config Config) (model.AuditReport, error) {
 	seenContributors := make(map[string]struct{})
 	firstMergedPulls := make(map[string]int)
 	for _, commit := range commits {
-		pulls, err := config.Client.PullRequestsForCommit(ctx, config.Repository, commit)
+		title, author, detailErr := gitCommitDetail(ctx, commit)
+		if detailErr != nil {
+			return model.AuditReport{}, detailErr
+		}
+		pulls, err := pullRequestsForCommit(ctx, config.Client, config.Repository, commit, title)
 		if err != nil {
-			return model.AuditReport{}, fmt.Errorf("lookup PRs for commit %s: %w", commit, err)
+			return model.AuditReport{}, err
 		}
 		if len(pulls) == 0 {
-			title, author, detailErr := gitCommitDetail(ctx, commit)
-			if detailErr != nil {
-				return model.AuditReport{}, detailErr
-			}
 			report.Sources = append(report.Sources, model.AuditSource{
 				Kind:   "commit",
 				URL:    "https://github.com/" + config.Repository + "/commit/" + commit,
@@ -253,6 +257,56 @@ func gitRevisionList(ctx context.Context, from, to string) ([]string, error) {
 		return nil, fmt.Errorf("no commits found for %s", revision)
 	}
 	return lines, nil
+}
+
+// pullRequestsForCommit 先使用 GitHub 的关联查询；squash merge 的最终 commit
+// 可能没有关联结果，此时仅在提交标题带有 GitHub 生成的 (#N) 后缀、且 PR
+// 的 merge_commit_sha 精确匹配时回溯 PR。这样既兼容 squash merge，也不会猜测来源。
+func pullRequestsForCommit(ctx context.Context, client github.Client, repository, commit, title string) ([]model.GitHubPullRequest, error) {
+	pulls, requestErr := client.PullRequestsForCommit(ctx, repository, commit)
+	if requestErr != nil {
+		pull, found, fallbackErr := squashPullRequest(ctx, client, repository, commit, title)
+		if fallbackErr == nil && found {
+			return []model.GitHubPullRequest{pull}, nil
+		}
+		if fallbackErr != nil {
+			return nil, fmt.Errorf("lookup PRs for commit %s: %w (squash fallback: %v)", commit, requestErr, fallbackErr)
+		}
+		return nil, fmt.Errorf("lookup PRs for commit %s: %w", commit, requestErr)
+	}
+	if len(pulls) > 0 {
+		return pulls, nil
+	}
+	pull, found, fallbackErr := squashPullRequest(ctx, client, repository, commit, title)
+	if fallbackErr != nil {
+		return nil, fmt.Errorf("resolve squash PR for commit %s: %w", commit, fallbackErr)
+	}
+	if found {
+		return []model.GitHubPullRequest{pull}, nil
+	}
+	return pulls, nil
+}
+
+func squashPullRequest(ctx context.Context, client github.Client, repository, commit, title string) (model.GitHubPullRequest, bool, error) {
+	matches := squashPullRequestPattern.FindStringSubmatch(title)
+	if len(matches) != 2 {
+		return model.GitHubPullRequest{}, false, nil
+	}
+	number, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return model.GitHubPullRequest{}, true, fmt.Errorf("parse PR number from commit title %q: %w", title, err)
+	}
+	pull, err := client.PullRequest(ctx, repository, number)
+	if err != nil {
+		return model.GitHubPullRequest{}, true, fmt.Errorf("lookup PR #%d: %w", number, err)
+	}
+	if pull.MergedAt == nil {
+		return model.GitHubPullRequest{}, true, fmt.Errorf("PR #%d is not merged", number)
+	}
+	if !strings.EqualFold(strings.TrimSpace(pull.MergeCommitSHA), commit) {
+		return model.GitHubPullRequest{}, true, fmt.Errorf("PR #%d merge_commit_sha %q does not match %s", number, pull.MergeCommitSHA, commit)
+	}
+	return pull, true, nil
 }
 
 func gitCommitDetail(ctx context.Context, commit string) (title, author string, err error) {

--- a/scripts/internal/releasenotes/audit/audit_test.go
+++ b/scripts/internal/releasenotes/audit/audit_test.go
@@ -1,11 +1,17 @@
 package audit
 
 import (
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/FlanChanXwO/javdb-cli/scripts/internal/releasenotes/github"
 	"github.com/FlanChanXwO/javdb-cli/scripts/internal/releasenotes/model"
 )
 
@@ -38,5 +44,66 @@ func TestPRValidateReadsEventPayload(t *testing.T) {
 	}
 	if err := ValidatePullRequestEvent(eventPath); err != nil {
 		t.Fatalf("validate PR event: %v", err)
+	}
+}
+
+func TestPullRequestsForCommitResolvesSquashMergeByExactPRCommit(t *testing.T) {
+	t.Parallel()
+
+	const commit = "a7f6e39e2e744fff4ca386f1aae6c7e99b640bc2"
+	mergedAt := time.Date(2026, time.August, 17, 0, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/repos/owner/project/commits/" + commit + "/pulls":
+			http.Error(response, "association unavailable", http.StatusInternalServerError)
+		case "/repos/owner/project/pulls/29":
+			_ = json.NewEncoder(response).Encode(model.GitHubPullRequest{
+				Number:         29,
+				Title:          "docs(release): prepare v0.7.2",
+				Body:           "<!-- release-note\ncategory: Documentation\nbreaking: false\nsummary: Prepare release notes.\nnone_reason:\n-->",
+				HTMLURL:        "https://github.com/owner/project/pull/29",
+				MergedAt:       &mergedAt,
+				MergeCommitSHA: commit,
+				User:           model.GitHubUser{Login: "owner", Type: "User"},
+			})
+		default:
+			http.Error(response, "unexpected GitHub API path "+request.URL.Path, http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	pulls, err := pullRequestsForCommit(
+		context.Background(),
+		github.New(server.URL, "", server.Client()),
+		"owner/project",
+		commit,
+		"docs(release): prepare v0.7.2 (#29)",
+	)
+	if err != nil {
+		t.Fatalf("resolve squash PR: %v", err)
+	}
+	if len(pulls) != 1 || pulls[0].Number != 29 {
+		t.Fatalf("pulls = %#v, want PR #29", pulls)
+	}
+}
+
+func TestPullRequestsForCommitPreservesUnattributedLookupFailure(t *testing.T) {
+	t.Parallel()
+
+	const commit = "abcdef0123456789"
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		http.Error(response, "association unavailable", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	_, err := pullRequestsForCommit(
+		context.Background(),
+		github.New(server.URL, "", server.Client()),
+		"owner/project",
+		commit,
+		"direct maintenance commit",
+	)
+	if err == nil || !strings.Contains(err.Error(), "lookup PRs for commit "+commit) {
+		t.Fatalf("error = %v, want lookup failure", err)
 	}
 }

--- a/scripts/internal/releasenotes/model/model.go
+++ b/scripts/internal/releasenotes/model/model.go
@@ -21,12 +21,13 @@ type GitHubUser struct {
 
 // GitHubPullRequest 是 release-note 审计所需的 PR 字段。
 type GitHubPullRequest struct {
-	Number   int        `json:"number"`
-	Title    string     `json:"title"`
-	Body     string     `json:"body"`
-	HTMLURL  string     `json:"html_url"`
-	MergedAt *time.Time `json:"merged_at"`
-	User     GitHubUser `json:"user"`
+	Number         int        `json:"number"`
+	Title          string     `json:"title"`
+	Body           string     `json:"body"`
+	HTMLURL        string     `json:"html_url"`
+	MergedAt       *time.Time `json:"merged_at"`
+	MergeCommitSHA string     `json:"merge_commit_sha"`
+	User           GitHubUser `json:"user"`
 }
 
 // GitHubPullRequestSearchResult 是 GitHub search/issues 响应的最小模型。


### PR DESCRIPTION
## Summary / 概述

修复 release-note audit 在 squash merge 后无法识别 PR 来源的问题，并把合并后最终 main commit 的审计、来源覆盖和 tag 前置检查写入 release skill 与维护者文档。同步补强 review、docs、commit-message 三个 project skill 的 PR/CI/门禁流程。

## Scope and compatibility / 范围与兼容性

不改变 CLI command、flag、public Go SDK、配置、认证、环境变量或输出契约。影响 release tooling、release behavior、maintainer documentation 和 operator skill files。squash fallback 只有在提交标题末尾存在 GitHub 生成的 `(#N)` 且对应 PR 的 `merge_commit_sha` 精确匹配时才生效；不匹配仍显式失败。

## Verification / 验证

```text
pre-commit run --all-files                         # passed
go test ./...                                      # passed
go test ./scripts/internal/releasenotes/...      # passed
sh scripts/build.sh                                # passed
sh scripts/test-releasenotes.sh                   # passed
sh scripts/test-documentation.sh                  # passed
sh scripts/test-workflows.sh                      # passed
go run ./scripts/releasenotes audit --repo FlanChanXwO/javdb-cli --from v0.7.1 --to v0.7.2 --output /tmp/javdb-release-v0.7.2-repaired-audit.json # passed
go run ./scripts/releasenotes validate --version 0.7.2 --previous v0.7.1 --dir changelog/v0.7.2 --audit /tmp/javdb-release-v0.7.2-repaired-audit.json # passed
真实 JavDB App API：未运行；仅读取 GitHub PR metadata。
```

## Release note declaration / Release note 声明

<!-- release-note
category: Maintenance
breaking: false
summary: Make release-note audit resolve squash-merged PRs by verifying the exact merge commit, and document the post-merge release preflight.
none_reason:
-->

## Checklist / 检查清单

- [x] The change is focused and linked to an issue when appropriate. / 改动目标明确，并在适用时关联 Issue。
- [x] I added or updated focused tests for changed behavior. / 我已为变更行为新增或更新聚焦测试。
- [x] I ran the relevant tests and recorded the results above. / 我已运行相关测试并在上方记录结果。
- [x] I updated the required CLI reference, SDK, README, maintainer, and operator-skill documentation. / 我已更新所需的 CLI reference、SDK、README、维护者和 operator-skill 文档。
- [x] I completed the required release-note declaration above; `None` has a concrete reason when selected. / 我已填写上方必需的 release-note 声明；选择 `None` 时已提供具体理由。
- [x] I documented the new source-attribution fallback and its exact-commit evidence. / 我已记录新增来源归因 fallback 及其精确提交证据。
- [x] I did not add passwords, JWTs, `~/.javdb-cli/auth.json` contents, proxy credentials, private URLs, local state, or private API responses. / 我没有添加密码、JWT、`~/.javdb-cli/auth.json` 内容、代理凭据、私有 URL、本地状态或私有 API 响应。
- [x] I updated migration guidance for every breaking change. / 我已为每个破坏性变更更新迁移指引；本次无 breaking change。

## Summary by Sourcery

改进发布说明审计功能，更稳健地归因被压缩合并（squash-merge）的 PR，并更新相关的发布与文档工作流。

Bug 修复：
- 通过将 GitHub 自动生成的提交标题与精确的合并提交进行匹配，确保发布说明审计能够归因被压缩合并的 PR。

增强功能：
- 添加一个支持压缩合并的 PR 解析助手，并扩展 GitHub 拉取请求元数据以包含用于审计归因的合并提交 SHA。
- 明确并强化维护者和项目技能文档，围绕合并后的发布审计、标签不可变性以及发布说明工作流进行说明。

文档：
- 更新双语变更日志条目，记录这项改进发布说明审计行为的维护性变更。

测试：
- 添加测试，覆盖压缩合并的回退解析路径，以及当针对某个提交的 PR 查询失败时的错误传播行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve release-note auditing to robustly attribute squash-merged PRs and update related release and documentation workflows.

Bug Fixes:
- Ensure release-note audit can attribute squash-merged PRs by matching GitHub-generated commit titles to exact merge commits.

Enhancements:
- Add a squash-merge-aware PR resolution helper and extend GitHub pull request metadata to include merge commit SHAs for audit attribution.
- Clarify and strengthen maintainer and project skill documentation around post-merge release audits, tag immutability, and release-note workflows.

Documentation:
- Update bilingual changelog entries to document the maintenance change improving release-note auditing behavior.

Tests:
- Add tests covering squash-merge fallback resolution and error propagation when PR lookup for a commit fails.

</details>