### PR TITLE
docs(release): prepare v0.7.2

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,7 +8,7 @@ grouped by user outcome and carry inline PR or historical direct-commit sources;
 | Version | Date | Release notes |
 | --- | --- | --- |
 | Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
-| [v0.7.2](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.1...v0.7.2) | 2026-08-16 | [English](v0.7.2/en.md) · [简体中文](v0.7.2/zh-CN.md) |
+| [v0.7.2](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.1...v0.7.2) | 2026-08-18 | [English](v0.7.2/en.md) · [简体中文](v0.7.2/zh-CN.md) |
 | [v0.7.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.0...v0.7.1) | 2026-08-14 | [English](v0.7.1/en.md) · [简体中文](v0.7.1/zh-CN.md) |
 | [v0.7.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.6.1...v0.7.0) | 2026-08-14 | [English](v0.7.0/en.md) · [简体中文](v0.7.0/zh-CN.md) |
 | [v0.6.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.6.0...v0.6.1) | 2026-08-13 | [English](v0.6.1/en.md) · [简体中文](v0.6.1/zh-CN.md) |

--- a/changelog/README.zh-CN.md
+++ b/changelog/README.zh-CN.md
@@ -5,7 +5,7 @@
 | 版本 | 日期 | 发布说明 |
 | --- | --- | --- |
 | Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
-| [v0.7.2](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.1...v0.7.2) | 2026-08-16 | [English](v0.7.2/en.md) · [简体中文](v0.7.2/zh-CN.md) |
+| [v0.7.2](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.1...v0.7.2) | 2026-08-18 | [English](v0.7.2/en.md) · [简体中文](v0.7.2/zh-CN.md) |
 | [v0.7.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.0...v0.7.1) | 2026-08-14 | [English](v0.7.1/en.md) · [简体中文](v0.7.1/zh-CN.md) |
 | [v0.7.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.6.1...v0.7.0) | 2026-08-14 | [English](v0.7.0/en.md) · [简体中文](v0.7.0/zh-CN.md) |
 | [v0.6.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.6.0...v0.6.1) | 2026-08-13 | [English](v0.6.1/en.md) · [简体中文](v0.6.1/zh-CN.md) |

--- a/changelog/v0.7.2/en.md
+++ b/changelog/v0.7.2/en.md
@@ -1,15 +1,26 @@
-# v0.7.2 — 2026-08-16
+# v0.7.2 — 2026-08-18
+
+## Breaking changes
+
+- Remove the hidden compatibility `javdb version` subcommand and its JSON shim. Use `javdb --version` for human-readable build information; CI, Homebrew, E2E checks, documentation, and the operator skill now use the root flag. ([#33](https://github.com/FlanChanXwO/javdb-cli/pull/33))
 
 ## Added
 
 - Add `search --magnets N`, stable magnet ranking and filtering, reverse-image magnet lookup, and fan-out pipeline records for movies and named entities. ([#29](https://github.com/FlanChanXwO/javdb-cli/pull/29))
 
+## Changed
+
+- Make versioned bilingual changelog directories the sole release-note source, remove the old plan/prepare and PR metadata flow, and let docs-only changes skip the native smoke matrix while retaining the aggregate platform gate. ([#31](https://github.com/FlanChanXwO/javdb-cli/pull/31))
+- Add automatic PR reviewer/assignee routing and path-based labels with pinned GitHub Actions. ([#33](https://github.com/FlanChanXwO/javdb-cli/pull/33))
+
 ## Fixed
 
 - Make non-TTY producer output consumable as stable refs, preserve upstream error envelopes, avoid redundant movie detail requests, report partial magnet and output failures correctly, and align real API smoke checks with the output contract. ([#29](https://github.com/FlanChanXwO/javdb-cli/pull/29))
+- Make release-note audit resolve squash-merged PRs by verifying the exact merge commit instead of relying on a direct commit-to-PR lookup. ([#30](https://github.com/FlanChanXwO/javdb-cli/pull/30))
+- Prevent skipped packaged-binary smoke jobs from exposing unexpanded matrix expressions, and align the bilingual issue templates. ([#32](https://github.com/FlanChanXwO/javdb-cli/pull/32))
 
 ## Maintenance
 
-- Make release-note audit resolve squash-merged PRs by verifying the exact merge commit, and document the post-merge release preflight across project skills and maintainer guidance. ([#30](https://github.com/FlanChanXwO/javdb-cli/pull/30))
+- Document the post-merge release preflight and final-main source audit required before creating an immutable release tag. ([#30](https://github.com/FlanChanXwO/javdb-cli/pull/30))
 
 **Full Changelog**: [v0.7.1...v0.7.2](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.1...v0.7.2)

--- a/changelog/v0.7.2/zh-CN.md
+++ b/changelog/v0.7.2/zh-CN.md
@@ -1,15 +1,26 @@
-# v0.7.2 — 2026-08-16
+# v0.7.2 — 2026-08-18
+
+## 破坏性变更
+
+- 删除隐藏的兼容 `javdb version` 子命令及其 JSON shim。请使用 `javdb --version` 查看人类可读的构建信息；CI、Homebrew、E2E 检查、文档和 operator skill 均已切换到根 flag。 ([#33](https://github.com/FlanChanXwO/javdb-cli/pull/33))
 
 ## 新增
 
 - 新增 `search --magnets N`、稳定的磁力排序与筛选、以图搜磁力，以及影片和命名实体的逐项管道记录输出。 ([#29](https://github.com/FlanChanXwO/javdb-cli/pull/29))
 
+## 变更
+
+- 以版本化双语 changelog 目录作为唯一 release-note 来源，删除旧的 plan/prepare 与 PR metadata 流程；纯文档变更跳过原生 smoke 矩阵，但仍保留聚合的 platform gate。 ([#31](https://github.com/FlanChanXwO/javdb-cli/pull/31))
+- 新增自动 PR reviewer/assignee 路由和基于路径的标签，并锁定 GitHub Actions 的提交版本。 ([#33](https://github.com/FlanChanXwO/javdb-cli/pull/33))
+
 ## 修复
 
 - 修复非 TTY producer 输出不可稳定消费、上游错误信封被重复处理、重复影片详情请求，以及部分磁力和输出失败未正确报告的问题，并让真实 API 冒烟检查与输出契约一致。 ([#29](https://github.com/FlanChanXwO/javdb-cli/pull/29))
+- 通过核对精确 merge commit 识别 squash merge 的 PR，避免依赖直接的 commit-to-PR 查询。 ([#30](https://github.com/FlanChanXwO/javdb-cli/pull/30))
+- 修复跳过矩阵时 packaged-binary smoke job 名称暴露未展开表达式的问题，并对齐双语 Issue 模板。 ([#32](https://github.com/FlanChanXwO/javdb-cli/pull/32))
 
 ## 维护
 
-- 让 release-note 审计通过核对精确 merge commit 识别 squash merge 的 PR，并在 project skills 和维护者文档中补充合并后的发布前置流程。 ([#30](https://github.com/FlanChanXwO/javdb-cli/pull/30))
+- 记录创建不可变 release tag 前必须以最终 main 提交执行发布前置检查和来源审计的流程。 ([#30](https://github.com/FlanChanXwO/javdb-cli/pull/30))
 
 **完整变更**：[v0.7.1...v0.7.2](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.1...v0.7.2)


### PR DESCRIPTION
## Summary / 概述

Prepare the bilingual `v0.7.2` release notes for the complete `v0.7.1..main` interval.

准备覆盖完整 `v0.7.1..main` 区间的 v0.7.2 双语发布说明。

The notes record the related merged PRs `#29`, `#30`, `#31`, `#32`, and `#33`, including the magnet/pipeline changes, release audit and source-flow changes, CI/template fixes, and removal of the legacy `javdb version` command.

## Scope and compatibility / 范围与兼容性

- This release-prep PR changes only `changelog/v0.7.2/{en.md,zh-CN.md}` and the two changelog indexes.
- No source code, public SDK, configuration, or environment-variable changes are introduced by this PR.
- The release notes identify the breaking migration from `javdb version` to `javdb --version`.

## Verification / 验证

```text
go run ./scripts/releasenotes audit --repo FlanChanXwO/javdb-cli --from v0.7.1 --to e51741f --output /tmp/javdb-release-audit-0.7.2.json (authenticated GitHub read): passed
go run ./scripts/releasenotes validate --version 0.7.2 --previous v0.7.1 --dir changelog/v0.7.2 --audit /tmp/javdb-release-audit-0.7.2.json: passed
go run ./scripts/releasenotes render --version 0.7.2 --dir changelog/v0.7.2: passed
sh scripts/test-releasenotes.sh: passed
pre-commit run --all-files: passed
git diff --check: passed
```

真实 JavDB App API 未运行；本 PR 只变更版本化 changelog 和索引。

## Checklist / 检查清单

- [x] The change is focused and linked to an issue when appropriate. / 改动目标明确；当前无适用 Issue。
- [x] I added or updated focused tests for changed behavior. / 本 PR 无代码行为变更；已运行 release-notes 门禁。
- [x] I ran the relevant tests and recorded the results above. / 已运行相关检查并记录结果。
- [x] I updated the required CLI reference, SDK, README, maintainer, and operator-skill documentation. / 本 PR 仅维护版本化 changelog；相关代码文档已在前置 PR 中更新。
- [x] I documented every new timeout, retry, pagination or result limit, truncation, fallback, or downgrade and its evidence. / 未新增此类限制或降级。
- [x] I did not add passwords, JWTs, `~/.javdb-cli/auth.json` contents, proxy credentials, private URLs, local state, or private API responses. / 未添加敏感信息。
- [x] I updated migration guidance for every breaking change. / 已在 v0.7.2 notes 中记录 `javdb --version` 迁移。

## Summary by Sourcery

为发布准备双语 v0.7.2 版本说明和变更日志索引。

Enhancements:
- 更新双语 v0.7.2 版本说明，使其覆盖完整的 v0.7.1..main 变更区间，包括版本命令迁移、发布工作流更新、CI 和模板修复以及发布审计改进。

Documentation:
- 记录 v0.7.2 中从 `javdb version` 迁移到 `javdb --version` 的破坏性变更，并在两个变更日志索引中更新发布日期。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prepare the bilingual v0.7.2 release notes and changelog indexes for publication.

Enhancements:
- Update the bilingual v0.7.2 release notes to cover the complete v0.7.1..main change interval, including the version-command migration, release workflow updates, CI and template fixes, and release audit improvements.

Documentation:
- Record the v0.7.2 breaking-change migration from `javdb version` to `javdb --version` and update both changelog indexes with the release date.

</details>