### PR TITLE
fix(release): synchronize ClawHub skill version

### DIFF
--- a/.agents/skills/javdb-cli-release-notes/SKILL.md
+++ b/.agents/skills/javdb-cli-release-notes/SKILL.md
@@ -41,14 +41,20 @@ description 或执行 `sync-history --apply` 前，必须在当前会话取得�
    `changelog/README.md` 和 `changelog/README.zh-CN.md`。每个条目必须带 PR 或 direct-commit 来源，
    两个 locale 的来源集合必须一致。`changelog/unreleased/` 只是可选人工草稿区，不会被发布 workflow 读取。
 
-4. 运行本地门禁：
+4. 维护随版本发布的 `skills/javdb-cli/`：若 `previous..main` 包含该目录的变更，必须在同一个
+   release-prep PR 中把 `skills/javdb-cli/SKILL.md` front matter 的唯一 `version:` 更新为目标
+   SemVer；若该目录没有变更，不要为发版机械修改版本号，ClawHub handoff 会跳过未改变的 skill。
+   创建 tag 前检查：变更时 `version` 必须等于目标版本，未变更时保留上一版本并确认 handoff
+   的 skip 分支可通过。
+
+5. 运行本地门禁：
 
    ```bash
    sh scripts/test-releasenotes.sh
    go run ./scripts/releasenotes validate --version X.Y.Z --previous "$previous" --dir changelog/vX.Y.Z
    ```
 
-5. 创建 release-prep PR，运行 required CI 并等待审查；tag 只能指向已合并的 release-prep commit。
+6. 创建 release-prep PR，运行 required CI 并等待审查；tag 只能指向已合并的 release-prep commit。
 
 `audit` 只确认 changelog 中引用的来源属于发布区间，不要求区间内每个 PR/commit 都必须出现在 notes 中；
 PR 正文不再承载或声明发布分类、摘要或版本升级信息。

--- a/.agents/skills/javdb-cli-release-notes/SKILL.md
+++ b/.agents/skills/javdb-cli-release-notes/SKILL.md
@@ -45,7 +45,8 @@ description 或执行 `sync-history --apply` 前，必须在当前会话取得�
    release-prep PR 中把 `skills/javdb-cli/SKILL.md` front matter 的唯一 `version:` 更新为目标
    SemVer；若该目录没有变更，不要为发版机械修改版本号，ClawHub handoff 会跳过未改变的 skill。
    创建 tag 前检查：变更时 `version` 必须等于目标版本，未变更时保留上一版本并确认 handoff
-   的 skip 分支可通过。
+   的 skip 分支可通过。同时同步 `README.md` 与 `README.zh-CN.md` 中 ClawHub 的当前 skill 版本；
+   该版本表示最新已发布的 skill，不是必须跟随 CLI 版本的独立数字，两处必须与 `SKILL.md` 一致。
 
 5. 运行本地门禁：
 

--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -87,15 +87,16 @@ jobs:
           test -n "$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq '.published_at')"
           skill_version=$(sed -n 's/^version: //p' skills/javdb-cli/SKILL.md)
           test "$(grep -c '^version: ' skills/javdb-cli/SKILL.md)" = 1
-          test "$skill_version" = "${RELEASE_TAG#v}"
           git cat-file -e "$RELEASE_TAG:skills/javdb-cli/SKILL.md"
           previous_tag=$(sh scripts/previous-release-tag.sh "$RELEASE_TAG")
           if [ -z "$previous_tag" ]; then
+            test "$skill_version" = "${RELEASE_TAG#v}"
             printf 'publish=true\n' >> "$GITHUB_OUTPUT"
           elif git diff --quiet "$previous_tag" "$RELEASE_TAG" -- skills/javdb-cli; then
             printf 'publish=false\n' >> "$GITHUB_OUTPUT"
             printf 'Skill unchanged since %s; skipping ClawHub publication.\n' "$previous_tag"
           else
+            test "$skill_version" = "${RELEASE_TAG#v}"
             printf 'publish=true\n' >> "$GITHUB_OUTPUT"
           fi
           printf 'commit=%s\n' "$tag_commit" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ flags with `javdb <command> --help`.
 
 Agents using ClawHub can install the published [`javdb-cli` Skill](https://clawhub.ai/flanchanxwo/skills/javdb-cli)
 with `clawhub install javdb-cli`; pin the installed skill to the matching
-published release version, currently `0.5.2`, rather than following an
+published release version, currently `0.7.2`, rather than following an
 unversioned `latest` tag.
 
 ## Authentication and credential safety

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -188,7 +188,7 @@ func main() {
 
 使用 ClawHub 的 Agent 可以通过 `clawhub install javdb-cli` 安装已发布的
 [`javdb-cli` Skill](https://clawhub.ai/flanchanxwo/skills/javdb-cli)；请将已安装的 skill 固定到对应的
-published release 版本（当前为 `0.5.2`），不要跟随无版本的 `latest` tag。
+published release 版本（当前为 `0.7.2`），不要跟随无版本的 `latest` tag。
 
 ## 认证与凭据安全
 

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -222,7 +222,9 @@ environment；旧兼容阶段已经结束，当前版本使用根 `--version`，
 6. `.github/CODEOWNERS` 将默认 review 路由到唯一维护者；它只会为未来 PR 请求 reviewer，不能让 PR 作者批准自己的 PR，也不替代 `main` 的分支保护要求。
 7. Release 在公开 GitHub Release 后上传只含不可变 tag 的 `clawhub-release-tag` artifact。成功结束的
    `Release` workflow 会由 `publish-clawhub.yml` 通过 `workflow_run` 消费；它 checkout 该 tag、验证
-   它属于默认分支，并跳过未改变的 `skills/javdb-cli/`。ClawHub 使用锁定的 `clawhub@0.23.1` 先做
+   它属于默认分支，并跳过未改变的 `skills/javdb-cli/`。若该 skill 在发布区间发生变更，
+   `skills/javdb-cli/SKILL.md` 的 front matter `version` 必须同步为目标发布版本；未变更时保留上一版本，
+   不应为发版机械改号。ClawHub 使用锁定的 `clawhub@0.23.1` 先做
    无凭据 dry-run，再在最后发布步骤读取 `CLAWHUB_TOKEN`。该 token 只应配置为仓库或受保护
    environment secret，绝不能写入 skill、workflow 日志或 Release notes。
 

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -224,7 +224,8 @@ environment；旧兼容阶段已经结束，当前版本使用根 `--version`，
    `Release` workflow 会由 `publish-clawhub.yml` 通过 `workflow_run` 消费；它 checkout 该 tag、验证
    它属于默认分支，并跳过未改变的 `skills/javdb-cli/`。若该 skill 在发布区间发生变更，
    `skills/javdb-cli/SKILL.md` 的 front matter `version` 必须同步为目标发布版本；未变更时保留上一版本，
-   不应为发版机械改号。ClawHub 使用锁定的 `clawhub@0.23.1` 先做
+   不应为发版机械改号。README 两个 locale 中 ClawHub 的当前 skill 版本也必须与该 front matter 一致。
+   ClawHub 使用锁定的 `clawhub@0.23.1` 先做
    无凭据 dry-run，再在最后发布步骤读取 `CLAWHUB_TOKEN`。该 token 只应配置为仓库或受保护
    environment secret，绝不能写入 skill、workflow 日志或 Release notes。
 

--- a/scripts/test-clawhub-publish-workflow.sh
+++ b/scripts/test-clawhub-publish-workflow.sh
@@ -39,6 +39,18 @@ grep -F 'git merge-base --is-ancestor' "$clawhub_workflow" >/dev/null
 grep -F "releases/tags/\$RELEASE_TAG" "$clawhub_workflow" >/dev/null
 grep -F "ref: $github_expr{{ steps.release_tag.outputs.value }}" "$clawhub_workflow" >/dev/null
 
+ruby - "$clawhub_workflow" <<'RUBY'
+path = ARGV.fetch(0)
+text = File.read(path)
+start = text.index("      - name: Verify immutable release and exact skill source")
+finish = text.index("      - name: Install pinned ClawHub CLI without credentials", start)
+abort("could not isolate ClawHub skill validation step") unless start && finish
+block = text[start...finish]
+needle = 'test "$skill_version" = "${RELEASE_TAG#v}"'
+abort("skill version must be checked only for changed skills") unless block.scan(needle).length == 2
+abort("skill version check must follow previous-tag diff detection") unless block.index("previous_tag=") < block.index(needle)
+RUBY
+
 grep -F 'clawhub@0.23.1' "$clawhub_workflow" >/dev/null
 grep -F 'clawhub skill publish skills/javdb-cli' "$clawhub_workflow" >/dev/null
 grep -F -- "--source-commit \"\$RELEASE_COMMIT\"" "$clawhub_workflow" >/dev/null

--- a/scripts/test-clawhub-publish-workflow.sh
+++ b/scripts/test-clawhub-publish-workflow.sh
@@ -67,3 +67,7 @@ for field in slug version displayName summary license homepage tags name descrip
 		exit 1
 	}
 done
+
+skill_version=$(sed -n 's/^version: //p' "$skill")
+grep -F "currently \`$skill_version\`" "$repo_root/README.md" >/dev/null
+grep -F "当前为 \`$skill_version\`" "$repo_root/README.zh-CN.md" >/dev/null

--- a/skills/javdb-cli/SKILL.md
+++ b/skills/javdb-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 slug: javdb-cli
-version: 0.7.1
+version: 0.7.2
 displayName: JavDB CLI
 summary: Safely operate JavDB through the javdb-cli binary for discovery, authenticated lists, and explicit state changes.
 license: MIT


### PR DESCRIPTION
## Summary

- Synchronize the tagged javdb-cli skill metadata to v0.7.2.
- Skip ClawHub publication when the skill is unchanged; require the target version only when it changed.
- Document the skill-version rule in the release skill and maintainer guide.

## Validation

- sh scripts/test-clawhub-publish-workflow.sh
- sh scripts/test-workflows.sh
- sh scripts/test-releasenotes.sh
- pre-commit run --all-files

This repairs the v0.7.2 release handoff before rebuilding the immutable tag.

## Summary by Sourcery

同步 ClawHub 技能版本处理逻辑与最新发布变更，并记录相应的发布要求。

Bug Fixes（错误修复）:
- 将 `javdb-cli` 的 ClawHub 技能元数据及已发布版本引用与 `v0.7.2` 版本保持同步。
- 仅在技能发生变更时才要求技能版本对齐，对于未变更的技能跳过 ClawHub 发布。

Enhancements（增强）:
- 为维护者撰写并补充技能版本同步以及发布交接的规则说明。

Documentation（文档）:
- 更新英文和中文 README 中对当前已发布技能版本的引用。

Tests（测试）:
- 扩展工作流校验范围，使其包含条件式技能版本检查以及对未变更技能的发布跳过验证。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Synchronize ClawHub skill version handling with release changes and document the resulting release requirements.

Bug Fixes:
- Synchronize the javdb-cli ClawHub skill metadata and published-version references with release v0.7.2.
- Require skill-version alignment only when the skill has changed, while skipping ClawHub publication for unchanged skills.

Enhancements:
- Document the skill-version synchronization and release handoff rules for maintainers.

Documentation:
- Update English and Chinese README references to the current published skill version.

Tests:
- Extend workflow validation to cover conditional skill-version checks and unchanged-skill publication skips.

</details>

Bug 修复：
- 将 `javdb-cli` 技能的元数据版本与 `v0.7.2` 发布版本同步。
- 对未发生变更的技能跳过 ClawHub 发布，同时对已变更的技能强制进行版本对齐。

增强功能：
- 为发布准备阶段和维护者编写文档，说明技能版本同步规则。

测试：
- 添加验证：仅在检测到相较于上一版本有变更后，ClawHub 才检查技能版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

同步 ClawHub 技能版本处理逻辑与最新发布变更，并记录相应的发布要求。

Bug Fixes（错误修复）:
- 将 `javdb-cli` 的 ClawHub 技能元数据及已发布版本引用与 `v0.7.2` 版本保持同步。
- 仅在技能发生变更时才要求技能版本对齐，对于未变更的技能跳过 ClawHub 发布。

Enhancements（增强）:
- 为维护者撰写并补充技能版本同步以及发布交接的规则说明。

Documentation（文档）:
- 更新英文和中文 README 中对当前已发布技能版本的引用。

Tests（测试）:
- 扩展工作流校验范围，使其包含条件式技能版本检查以及对未变更技能的发布跳过验证。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Synchronize ClawHub skill version handling with release changes and document the resulting release requirements.

Bug Fixes:
- Synchronize the javdb-cli ClawHub skill metadata and published-version references with release v0.7.2.
- Require skill-version alignment only when the skill has changed, while skipping ClawHub publication for unchanged skills.

Enhancements:
- Document the skill-version synchronization and release handoff rules for maintainers.

Documentation:
- Update English and Chinese README references to the current published skill version.

Tests:
- Extend workflow validation to cover conditional skill-version checks and unchanged-skill publication skips.

</details>

</details>