### PR TITLE
docs: replace pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,37 +1,31 @@
-<!-- Localized instructions: English / 中文 -->
-
-## Summary / 概述
-
 <!--
-English: Describe the user problem and the change that addresses it. Link related issues with "Fixes #123" when applicable.
-中文：说明用户问题及解决该问题的改动。适用时使用 “Fixes #123” 关联 Issue。
+提交前确认：不含 token、cookie、私有地址、下载内容或本地数据。
+Before submitting: no tokens, cookies, private URLs, downloads, or local data.
 -->
 
-## Scope and compatibility / 范围与兼容性
-
 <!--
-English: List affected CLI commands or flags, public Go SDK APIs, configuration, environment variables, output contracts, operator skill files, and release behavior. State "None" when there is no public impact. Do not claim MCP support: javdb-cli has no MCP server.
-中文：列出受影响的 CLI command 或 flag、public Go SDK API、配置、环境变量、输出契约、operator skill 文件和发布行为。没有公开影响时填写 “None”。javdb-cli 没有 MCP server，不要声称 MCP 支持。
+Closes #123
 -->
 
-## Verification / 验证
+## 变更点 / Changes
 
 <!--
-English: List the exact commands you ran and their results. For real JavDB App API coverage, state whether it was run and use only redacted evidence.
-中文：列出实际运行的精确命令及结果。真实 JavDB App API 覆盖须说明是否运行，且只提供脱敏证据。
+列要点：改动 + 原因。关联 Issue 用 `Closes #123`（合并后关闭）。
+Bullet the change and why. Link an issue with `Closes #123` (closes on merge).
 -->
 
-```text
-go test ./...
-sh scripts/build.sh
-```
+## 验证步骤 / Verification
 
-## Checklist / 检查清单
+<!--
+实际运行的命令和结果/截图。例如 / Commands and results/Screenshot. E.g.
+- `go test ./...`
+- `sh scripts/build.sh`
+未测试时说明原因。 / If not tested, explain why.
+-->
 
-- [ ] The change is focused and linked to an issue when appropriate. / 改动目标明确，并在适用时关联 Issue。
-- [ ] I added or updated focused tests for changed behavior. / 我已为变更行为新增或更新聚焦测试。
-- [ ] I ran the relevant tests and recorded the results above. / 我已运行相关测试并在上方记录结果。
-- [ ] I updated the required CLI reference, SDK, README, maintainer, and operator-skill documentation. / 我已更新所需的 CLI reference、SDK、README、维护者和 operator-skill 文档。
-- [ ] I documented every new timeout, retry, pagination or result limit, truncation, fallback, or downgrade and its evidence. / 我已记录每项新增 timeout、retry、pagination 或结果限制、truncation、fallback 或 downgrade 及其证据。
-- [ ] I did not add passwords, JWTs, `~/.javdb-cli/auth.json` contents, proxy credentials, private URLs, local state, or private API responses. / 我没有添加密码、JWT、`~/.javdb-cli/auth.json` 内容、代理凭据、私有 URL、本地状态或私有 API 响应。
-- [ ] I updated migration guidance for every breaking change. / 我已为每个破坏性变更更新迁移指引。
+## 检查清单 / Checklist
+
+- [ ] 我没有引入恶意代码 / No malicious code
+- [ ] 我没有新增依赖，或已在 `go.mod`（或 Rust `Cargo.toml`）的补充新的依赖 / No new dependencies, or added name, source, and purpose to `go.mod` (or Rust `Cargo.toml`) in Changes
+- [ ] 这不是一次破坏性更新，或已在「变更点」标注迁移影响 / Not a breaking change, or migration impact noted in Changes
+- [ ] 受影响的文档已在 `docs/en/` 与 `docs/zh-CN/` 同步 / Affected docs synced under `docs/en/` and `docs/zh-CN/`


### PR DESCRIPTION
## 变更点 / Changes

- 用 pixiv-cli 的 PR 模板替换 javdb-cli 的 `.github/PULL_REQUEST_TEMPLATE.md`。
- 仅修改 PR 模板，不涉及 `javdb update`、Release workflow 或发布脚本。

## 验证步骤 / Verification

- `cmp -s`：目标模板与 pixiv-cli 模板完全一致。
- `git diff --check`：通过。
- `go test ./scripts/changescope`：通过。
- `go test ./internal/update/...`：通过。
- `sh scripts/test-workflows.sh`：通过。
- `sh scripts/test-package-release.sh`：通过。
- `sh scripts/test-clawhub-publish-workflow.sh`：通过。
- `go test ./...`：通过。
- `sh scripts/build.sh`：通过。

真实 JavDB App API：未运行，本次仅修改文档。

## Sourcery 摘要

替换拉取请求模板，以提供更清晰的双语贡献指南和验证要求。

改进：
- 将拉取请求模板替换为精简的双语模板，重点说明变更描述、验证步骤和贡献者保障措施。

文档：
- 更新仓库的拉取请求指南和检查清单，包括问题链接、依赖项披露、迁移影响以及文档同步要求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace the pull request template to provide clearer bilingual contribution guidance and verification requirements.

Enhancements:
- Replace the pull request template with a streamlined bilingual template focused on change descriptions, verification steps, and contributor safeguards.

Documentation:
- Update the repository’s pull request guidance and checklist, including issue linking, dependency disclosures, migration impact, and synchronized documentation expectations.

</details>