### PR TITLE
ci(release): publish container images to Docker Hub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,14 +337,15 @@ jobs:
           git merge-base --is-ancestor HEAD "origin/$DEFAULT_BRANCH"
 
   publish:
-    name: Publish GitHub Release
+    name: Publish release and container images
     needs: [validate, verify_release_source, release_notes_audit, build_container]
     runs-on: ubuntu-24.04
-    # 受保护 environment：只有这里允许读取签名私钥。缺失 secret 或未配置
-    # required reviewers 时 job 显式失败（fail-closed），不发布未签名资产。
+    # 受保护 environment：只有这里允许读取签名私钥与 Docker Hub token。缺失 secret
+    # 或未配置 required reviewers 时 job 显式失败（fail-closed），不公开不完整 Release。
     environment: release
     permissions:
       contents: write
+      packages: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -380,6 +381,14 @@ jobs:
         with:
           name: verified-release-windows-arm64
           path: dist
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: verified-container-linux-amd64
+          path: containers
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: verified-container-linux-arm64
+          path: containers
 
       - name: Check the exact release asset set and sign the release manifest
         shell: bash
@@ -423,17 +432,22 @@ jobs:
             --version "${RELEASE_TAG#v}" \
             --dir "changelog/v${RELEASE_TAG#v}" \
             --output release/release-notes.md
-          gh release create "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --draft \
-            --verify-tag \
-            --title "$RELEASE_TAG" \
-            --notes-file release/release-notes.md \
-            dist/javdb-cli_*.tar.gz \
-            dist/javdb-cli_*.zip \
-            dist/checksums.txt \
-            dist/release-manifest.json \
-            dist/release-manifest.sig
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            # failed-job rerun 只允许复用本次 workflow 已创建但尚未公开的 draft。
+            test "$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')" = true
+          else
+            gh release create "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --draft \
+              --verify-tag \
+              --title "$RELEASE_TAG" \
+              --notes-file release/release-notes.md \
+              dist/javdb-cli_*.tar.gz \
+              dist/javdb-cli_*.zip \
+              dist/checksums.txt \
+              dist/release-manifest.json \
+              dist/release-manifest.sig
+          fi
           expected=$(find dist -maxdepth 1 -type f -exec basename {} \; | LC_ALL=C sort)
           actual=$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' | LC_ALL=C sort)
           if [ "$actual" != "$expected" ]; then
@@ -442,7 +456,89 @@ jobs:
             printf '%s\n' "actual:$actual" >&2
             exit 1
           fi
-          gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false
+
+      - name: Load the verified container images
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker load --input containers/javdb-cli-linux-amd64.tar
+          docker load --input containers/javdb-cli-linux-arm64.tar
+
+      - name: Log in to the GHCR
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20
+        with:
+          registry: docker.io
+          username: flanchanxwo
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Tag and push per-architecture images
+        shell: bash
+        run: |
+          set -euo pipefail
+          for goarch in amd64 arm64; do
+            image="javdb-cli:${RELEASE_TAG}-linux-${goarch}"
+            docker tag "$image" "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-${goarch}"
+            docker push "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-${goarch}"
+            docker tag "$image" "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-${goarch}"
+            docker push "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-${goarch}"
+          done
+
+      - name: Publish the versioned multi-architecture manifests
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker manifest create "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}" \
+            "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-amd64" \
+            "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-arm64"
+          docker manifest push "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}"
+          docker manifest create "flanchanxwo/javdb-cli:${RELEASE_TAG}" \
+            "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-amd64" \
+            "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-arm64"
+          docker manifest push "flanchanxwo/javdb-cli:${RELEASE_TAG}"
+
+      - name: Promote latest only for the newest stable tag
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          latest_stable_tag=$(gh api --paginate "repos/$GITHUB_REPOSITORY/git/matching-refs/tags/v" \
+            --jq '.[].ref | sub("refs/tags/"; "")' \
+            | grep -E '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' \
+            | sort -V | tail -n 1)
+          if [ "$RELEASE_TAG" = "$latest_stable_tag" ]; then
+            docker manifest create "ghcr.io/flanchanxwo/javdb-cli:latest" \
+              "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-amd64" \
+              "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-arm64"
+            docker manifest push "ghcr.io/flanchanxwo/javdb-cli:latest"
+            docker manifest create "flanchanxwo/javdb-cli:latest" \
+              "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-amd64" \
+              "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-arm64"
+            docker manifest push "flanchanxwo/javdb-cli:latest"
+          else
+            printf 'Skipping latest promotion: %s is not the newest stable tag (%s)\n' \
+              "$RELEASE_TAG" "$latest_stable_tag"
+          fi
+
+      - name: Verify the Docker Hub manifest is public
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker logout docker.io
+          docker manifest inspect "docker.io/flanchanxwo/javdb-cli:${RELEASE_TAG}" >/dev/null
+
+      - name: Publish the GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false
 
       # ClawHub 发布 workflow 只信任这个由已公开 Release 生成的 tag handoff；
       # 不从 workflow_run 的 head_branch 推断版本，也不重新读取 main。
@@ -571,96 +667,6 @@ jobs:
           if-no-files-found: error
           # 保留足够久以便恢复已发布镜像；镜像引用 git 存储（不是依赖重新构建的易失资产）。
           retention-days: 90
-
-  publish_container:
-    name: Publish the multi-architecture container images
-    needs: [build_container, publish]
-    runs-on: ubuntu-24.04
-    # Docker Hub token 与发布签名密钥同属 release environment；缺失凭据时显式失败，
-    # 不把只发布到单一 registry 的部分结果报告为完整容器发布成功。
-    environment: release
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        with:
-          name: verified-container-linux-amd64
-          path: containers
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        with:
-          name: verified-container-linux-arm64
-          path: containers
-
-      - name: Load the verified images
-        shell: bash
-        run: |
-          set -euo pipefail
-          docker load --input containers/javdb-cli-linux-amd64.tar
-          docker load --input containers/javdb-cli-linux-arm64.tar
-
-      - name: Log in to the GHCR
-        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20
-        with:
-          registry: docker.io
-          username: flanchanxwo
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
-      - name: Tag and push per-architecture images
-        shell: bash
-        run: |
-          set -euo pipefail
-          for goarch in amd64 arm64; do
-            image="javdb-cli:${RELEASE_TAG}-linux-${goarch}"
-            docker tag "$image" "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-${goarch}"
-            docker push "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-${goarch}"
-            docker tag "$image" "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-${goarch}"
-            docker push "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-${goarch}"
-          done
-
-      - name: Publish the versioned multi-architecture manifest
-        shell: bash
-        run: |
-          set -euo pipefail
-          docker manifest create "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}" \
-            "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-amd64" \
-            "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-arm64"
-          docker manifest push "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}"
-          docker manifest create "flanchanxwo/javdb-cli:${RELEASE_TAG}" \
-            "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-amd64" \
-            "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-arm64"
-          docker manifest push "flanchanxwo/javdb-cli:${RELEASE_TAG}"
-
-      - name: Promote latest only for the newest stable tag
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          latest_stable_tag=$(gh api --paginate "repos/$GITHUB_REPOSITORY/git/matching-refs/tags/v" \
-            --jq '.[].ref | sub("refs/tags/"; "")' \
-            | grep -E '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' \
-            | sort -V | tail -n 1)
-          if [ "$RELEASE_TAG" = "$latest_stable_tag" ]; then
-            docker manifest create "ghcr.io/flanchanxwo/javdb-cli:latest" \
-              "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-amd64" \
-              "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-arm64"
-            docker manifest push "ghcr.io/flanchanxwo/javdb-cli:latest"
-            docker manifest create "flanchanxwo/javdb-cli:latest" \
-              "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-amd64" \
-              "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-arm64"
-            docker manifest push "flanchanxwo/javdb-cli:latest"
-          else
-            printf 'Skipping latest promotion: %s is not the newest stable tag (%s)\n' \
-              "$RELEASE_TAG" "$latest_stable_tag"
-          fi
 
   render_homebrew_formula:
     name: Render Homebrew formula

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -573,9 +573,12 @@ jobs:
           retention-days: 90
 
   publish_container:
-    name: Publish the multi-architecture container image
+    name: Publish the multi-architecture container images
     needs: [build_container, publish]
     runs-on: ubuntu-24.04
+    # Docker Hub token 与发布签名密钥同属 release environment；缺失凭据时显式失败，
+    # 不把只发布到单一 registry 的部分结果报告为完整容器发布成功。
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -603,6 +606,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20
+        with:
+          registry: docker.io
+          username: flanchanxwo
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
       - name: Tag and push per-architecture images
         shell: bash
         run: |
@@ -611,6 +621,8 @@ jobs:
             image="javdb-cli:${RELEASE_TAG}-linux-${goarch}"
             docker tag "$image" "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-${goarch}"
             docker push "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-${goarch}"
+            docker tag "$image" "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-${goarch}"
+            docker push "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-${goarch}"
           done
 
       - name: Publish the versioned multi-architecture manifest
@@ -621,6 +633,10 @@ jobs:
             "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-amd64" \
             "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-arm64"
           docker manifest push "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}"
+          docker manifest create "flanchanxwo/javdb-cli:${RELEASE_TAG}" \
+            "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-amd64" \
+            "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-arm64"
+          docker manifest push "flanchanxwo/javdb-cli:${RELEASE_TAG}"
 
       - name: Promote latest only for the newest stable tag
         shell: bash
@@ -637,6 +653,10 @@ jobs:
               "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-amd64" \
               "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-arm64"
             docker manifest push "ghcr.io/flanchanxwo/javdb-cli:latest"
+            docker manifest create "flanchanxwo/javdb-cli:latest" \
+              "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-amd64" \
+              "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-arm64"
+            docker manifest push "flanchanxwo/javdb-cli:latest"
           else
             printf 'Skipping latest promotion: %s is not the newest stable tag (%s)\n' \
               "$RELEASE_TAG" "$latest_stable_tag"

--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ The release contract covers macOS, Linux, and Windows on amd64 and arm64. See
 the [development guide](docs/maintainers/development.md#构建打包与平台)
 for reproducible target builds and archive contents.
 
-### Docker (GHCR)
+### Docker (GHCR and Docker Hub)
 
-Every stable release also publishes a multi-architecture image
-(`linux/amd64` and `linux/arm64`) on the GitHub Container Registry. The image
-runs as a non-root user and keeps local state under
+Every stable release also publishes the same multi-architecture image
+(`linux/amd64` and `linux/arm64`) to the GitHub Container Registry and Docker
+Hub. The image runs as a non-root user and keeps local state under
 `/home/javdb/.javdb-cli` (created with private `0700` permissions); mount a named
 volume there to persist login and cache between runs. The default `/work`
 directory is writable by `javdb`, so relative download output paths work without
@@ -104,6 +104,7 @@ additional bind mounts.
 
 ```bash
 docker run --rm ghcr.io/flanchanxwo/javdb-cli:v0.2.0 --version
+# The equivalent Docker Hub image is flanchanxwo/javdb-cli:v0.2.0.
 
 # 挂载命名卷持久化登录状态与缓存；容器内默认工作目录是 /work。
 docker run --rm -v javdb-cli-state:/home/javdb/.javdb-cli \
@@ -112,9 +113,9 @@ docker run --rm -v javdb-cli-state:/home/javdb/.javdb-cli \
   ghcr.io/flanchanxwo/javdb-cli:latest search SSIS-589 --limit 5
 ```
 
-`latest` points at the newest stable release; exact version tags
-(`vX.Y.Z`) and per-architecture tags (`vX.Y.Z-linux-amd64`,
-`vX.Y.Z-linux-arm64`) are also published.
+Both registries publish `latest` for the newest stable release, exact version
+tags (`vX.Y.Z`), and per-architecture tags (`vX.Y.Z-linux-amd64`,
+`vX.Y.Z-linux-arm64`).
 
 ### Update
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ additional bind mounts.
 
 ```bash
 docker run --rm ghcr.io/flanchanxwo/javdb-cli:v0.2.0 --version
-# The equivalent Docker Hub image is flanchanxwo/javdb-cli:v0.2.0.
 
 # 挂载命名卷持久化登录状态与缓存；容器内默认工作目录是 /work。
 docker run --rm -v javdb-cli-state:/home/javdb/.javdb-cli \
@@ -112,6 +111,9 @@ docker run --rm -v javdb-cli-state:/home/javdb/.javdb-cli \
 docker run --rm -v javdb-cli-state:/home/javdb/.javdb-cli \
   ghcr.io/flanchanxwo/javdb-cli:latest search SSIS-589 --limit 5
 ```
+
+Docker Hub images are published for stable releases created after that channel
+is enabled. For those releases, use `flanchanxwo/javdb-cli` with the same tag.
 
 Both registries publish `latest` for the newest stable release, exact version
 tags (`vX.Y.Z`), and per-architecture tags (`vX.Y.Z-linux-amd64`,

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -89,7 +89,6 @@ sh scripts/build.sh
 
 ```bash
 docker run --rm ghcr.io/flanchanxwo/javdb-cli:v0.2.0 --version
-# 对应的 Docker Hub 镜像是 flanchanxwo/javdb-cli:v0.2.0。
 
 # 挂载命名卷持久化登录状态与缓存；容器内默认工作目录是 /work。
 docker run --rm -v javdb-cli-state:/home/javdb/.javdb-cli \
@@ -97,6 +96,9 @@ docker run --rm -v javdb-cli-state:/home/javdb/.javdb-cli \
 docker run --rm -v javdb-cli-state:/home/javdb/.javdb-cli \
   ghcr.io/flanchanxwo/javdb-cli:latest search SSIS-589 --limit 5
 ```
+
+Docker Hub 镜像从启用该发布渠道后的 stable release 开始提供；这些版本可使用相同 tag，
+镜像名为 `flanchanxwo/javdb-cli`。
 
 两个 registry 都为最新 stable release 发布 `latest`，并发布精确版本 tag（`vX.Y.Z`）与
 分架构 tag（`vX.Y.Z-linux-amd64`、`vX.Y.Z-linux-arm64`）。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -80,15 +80,16 @@ sh scripts/build.sh
 发布契约覆盖 macOS、Linux、Windows 的 amd64 与 arm64。可复现目标构建及归档内容见
 [开发指南](docs/maintainers/development.md#构建打包与平台)。
 
-### Docker（GHCR）
+### Docker（GHCR 与 Docker Hub）
 
-每个 stable release 还会在 GitHub Container Registry 发布多架构镜像
+每个 stable release 还会向 GitHub Container Registry 与 Docker Hub 发布相同的多架构镜像
 （`linux/amd64` 与 `linux/arm64`）。镜像以非 root 用户运行，本地状态保存在
 `/home/javdb/.javdb-cli`（按私有 `0700` 权限创建）；把命名卷挂载到该目录即可持久化登录状态与缓存。
 默认 `/work` 由 `javdb` 用户可写，因此相对下载输出路径无需额外挂载即可使用。
 
 ```bash
 docker run --rm ghcr.io/flanchanxwo/javdb-cli:v0.2.0 --version
+# 对应的 Docker Hub 镜像是 flanchanxwo/javdb-cli:v0.2.0。
 
 # 挂载命名卷持久化登录状态与缓存；容器内默认工作目录是 /work。
 docker run --rm -v javdb-cli-state:/home/javdb/.javdb-cli \
@@ -97,8 +98,8 @@ docker run --rm -v javdb-cli-state:/home/javdb/.javdb-cli \
   ghcr.io/flanchanxwo/javdb-cli:latest search SSIS-589 --limit 5
 ```
 
-`latest` 指向最新的 stable release；同时发布精确版本 tag（`vX.Y.Z`）与分架构 tag
-（`vX.Y.Z-linux-amd64`、`vX.Y.Z-linux-arm64`）。
+两个 registry 都为最新 stable release 发布 `latest`，并发布精确版本 tag（`vX.Y.Z`）与
+分架构 tag（`vX.Y.Z-linux-amd64`、`vX.Y.Z-linux-arm64`）。
 
 ### 更新
 

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -175,13 +175,16 @@ docker build --build-arg REVISION="$(git rev-parse HEAD)" --build-arg VERSION=v0
 `ubuntu-22.04` / `ubuntu-22.04-arm` 上从不可变 tag 重建二进制、构建并验证镜像
 契约（非 root、版本字符串、状态目录、工作目录、许可证与 OCI labels），再
 `docker save` 上传 `verified-container-*` artifact（保留 90 天）。
-`publish_container` job 使用 `GITHUB_TOKEN` 登录 GHCR，并使用受保护 `release`
-environment 中的 `DOCKER_HUB_TOKEN` 登录 Docker Hub；随后向两个 registry 推送分架构镜像，
-并分别发布多架构 manifest `ghcr.io/flanchanxwo/javdb-cli:vX.Y.Z` 与
+`publish` job 在单次受保护 `release` environment gate 后，使用 `GITHUB_TOKEN` 登录 GHCR，
+并使用 `DOCKER_HUB_TOKEN` 登录 Docker Hub；随后向两个 registry 推送分架构镜像，分别发布
+多架构 manifest `ghcr.io/flanchanxwo/javdb-cli:vX.Y.Z` 与
 `flanchanxwo/javdb-cli:vX.Y.Z`。仅当该 tag 是仓库最新 stable tag 时，才把两个 registry 的
-`latest` 指到对应 manifest；较旧 stable tag 会正常跳过 promotion。Docker Hub namespace
-固定为 `flanchanxwo`，token 必须具有该 repository 的 push 权限。
-`publish` 依赖 `build_container`，因此镜像验证失败时不会先公开 GitHub Release。
+`latest` 指到对应 manifest；较旧 stable tag 会正常跳过 promotion。同一 job 先创建并审计 draft
+GitHub Release，双 registry 发布成功后才将其公开，因此不需要第二次 environment approval。
+Docker Hub namespace 固定为 `flanchanxwo`，token 必须具有该 repository 的 push 权限。
+发布器登出 Docker Hub 后匿名读取版本 manifest，以确认 repository 对公众可见。任一 registry push
+或公开读取验证失败时，job 显式失败且不会公开 GitHub Release；修复外部状态后可重跑 failed job，
+重复 push 相同版本 tag 会用于补齐另一 registry，不执行跨 registry rollback。
 镜像变更（`Dockerfile` / `.dockerignore` / `container-smoke.yml` /
 `scripts/build-release.sh` / `go.mod` / `go.sum` / `cmd/**` / `internal/**` /
 `sdk/**` / `LICENSE`）由 `container-smoke` workflow 在 PR 与 main 上验证。
@@ -255,9 +258,10 @@ environment；旧兼容阶段已经结束，当前版本使用根 `--version`，
    Homebrew Formula，并在 macOS/Linux 的 amd64/arm64 环境验证。tap 部署是可选的：必须设置
    `HOMEBREW_TAP_DEPLOY_ENABLED=true` 并在受保护 `release` environment 配置
    `HOMEBREW_TAP_DEPLOY_KEY`；条件缺失时 Release 与 Formula 验证仍会完成。
-   容器发布紧随 `publish`：`publish` 先等待 `build_container` 从同一不可变 tag 重建 Linux
-   二进制并验证镜像契约，镜像验证失败时不会创建公开 GitHub Release；`publish_container`
-   只消费已验证的 `verified-container-*` tar 推 GHCR 与 Docker Hub 并发布多架构 manifest；
+   `publish` 先等待 `build_container` 从同一不可变 tag 重建 Linux 二进制并验证镜像契约，
+   再在同一次 `release` environment approval 后创建并审计 draft GitHub Release、消费
+   `verified-container-*` tar，推 GHCR 与 Docker Hub 并发布多架构 manifest；双 registry
+   成功后才将 GitHub Release 公开。
    `latest` 仅指向最新 stable tag，较旧 tag 的 promotion 是正常 skip。
 6. `.github/CODEOWNERS` 将默认 review 路由到唯一维护者；它只会为未来 PR 请求 reviewer，不能让 PR 作者批准自己的 PR，也不替代 `main` 的分支保护要求。
 7. Release 在公开 GitHub Release 后上传只含不可变 tag 的 `clawhub-release-tag` artifact。成功结束的

--- a/docs/maintainers/development.md
+++ b/docs/maintainers/development.md
@@ -152,7 +152,8 @@ Windows Git Bash runner 用预装 `7z` 生成 ZIP。
 
 ### Docker 镜像
 
-每个 stable release 额外发布 GHCR 多架构镜像（`linux/amd64`、`linux/arm64`）。
+每个 stable release 向 GHCR 与 Docker Hub 发布相同的多架构镜像
+（`linux/amd64`、`linux/arm64`）。
 容器契约固定为：pinned `debian:bookworm-slim`（manifest digest）、非 root 用户
 `javdb`（UID 1000）、私有权限 `0700` 的状态目录 `/home/javdb/.javdb-cli`、
 由 `javdb` 用户可写的工作目录 `/work`、`ENTRYPOINT ["/usr/local/bin/javdb"]`，
@@ -174,9 +175,12 @@ docker build --build-arg REVISION="$(git rev-parse HEAD)" --build-arg VERSION=v0
 `ubuntu-22.04` / `ubuntu-22.04-arm` 上从不可变 tag 重建二进制、构建并验证镜像
 契约（非 root、版本字符串、状态目录、工作目录、许可证与 OCI labels），再
 `docker save` 上传 `verified-container-*` artifact（保留 90 天）。
-`publish_container` job 登录 GHCR、推送分架构镜像并发布多架构 manifest
-`ghcr.io/flanchanxwo/javdb-cli:vX.Y.Z`；仅当该 tag 是仓库最新 stable tag 时
-才把 `latest` 指到该 manifest，较旧 stable tag 会正常跳过该 promotion。
+`publish_container` job 使用 `GITHUB_TOKEN` 登录 GHCR，并使用受保护 `release`
+environment 中的 `DOCKER_HUB_TOKEN` 登录 Docker Hub；随后向两个 registry 推送分架构镜像，
+并分别发布多架构 manifest `ghcr.io/flanchanxwo/javdb-cli:vX.Y.Z` 与
+`flanchanxwo/javdb-cli:vX.Y.Z`。仅当该 tag 是仓库最新 stable tag 时，才把两个 registry 的
+`latest` 指到对应 manifest；较旧 stable tag 会正常跳过 promotion。Docker Hub namespace
+固定为 `flanchanxwo`，token 必须具有该 repository 的 push 权限。
 `publish` 依赖 `build_container`，因此镜像验证失败时不会先公开 GitHub Release。
 镜像变更（`Dockerfile` / `.dockerignore` / `container-smoke.yml` /
 `scripts/build-release.sh` / `go.mod` / `go.sum` / `cmd/**` / `internal/**` /
@@ -253,8 +257,8 @@ environment；旧兼容阶段已经结束，当前版本使用根 `--version`，
    `HOMEBREW_TAP_DEPLOY_KEY`；条件缺失时 Release 与 Formula 验证仍会完成。
    容器发布紧随 `publish`：`publish` 先等待 `build_container` 从同一不可变 tag 重建 Linux
    二进制并验证镜像契约，镜像验证失败时不会创建公开 GitHub Release；`publish_container`
-   只消费已验证的 `verified-container-*` tar 推 GHCR 并发布多架构 manifest；`latest` 仅指向
-   最新 stable tag，较旧 tag 的 promotion 是正常 skip。
+   只消费已验证的 `verified-container-*` tar 推 GHCR 与 Docker Hub 并发布多架构 manifest；
+   `latest` 仅指向最新 stable tag，较旧 tag 的 promotion 是正常 skip。
 6. `.github/CODEOWNERS` 将默认 review 路由到唯一维护者；它只会为未来 PR 请求 reviewer，不能让 PR 作者批准自己的 PR，也不替代 `main` 的分支保护要求。
 7. Release 在公开 GitHub Release 后上传只含不可变 tag 的 `clawhub-release-tag` artifact。成功结束的
    `Release` workflow 会由 `publish-clawhub.yml` 通过 `workflow_run` 消费；它 checkout 该 tag、验证

--- a/scripts/test-workflows.sh
+++ b/scripts/test-workflows.sh
@@ -93,27 +93,39 @@ grep -F 'scripts/releasenotes render' "$release_workflow" >/dev/null
 grep -F -- '--notes-file release/release-notes.md' "$release_workflow" >/dev/null
 grep -F 'gh release create "$RELEASE_TAG"' "$release_workflow" >/dev/null
 grep -F 'HOMEBREW_TAP_DEPLOY_ENABLED' "$release_workflow" >/dev/null
-# 容器镜像发布：build_container 从同一不可变 tag 重建 Linux 二进制、构建并验证镜像契约，
-# publish 等待它成功后才公开 Release；publish_container 只消费已验证镜像推 GHCR 并发布多架构 manifest。
+# 容器镜像发布：build_container 从同一不可变 tag 重建 Linux 二进制、构建并验证镜像契约；
+# publish 在同一次 release environment gate 中消费已验证镜像，推送 GHCR 与 Docker Hub，最后公开 Release。
 grep -F 'build_container:' "$release_workflow" >/dev/null
-grep -F 'publish_container:' "$release_workflow" >/dev/null
-grep -F 'needs: [build_container, publish]' "$release_workflow" >/dev/null
-grep -F 'packages: write' "$release_workflow" >/dev/null
-grep -F 'verified-container-${{ matrix.artifact }}' "$release_workflow" >/dev/null
-publish_container=$(sed -n '/^  publish_container:$/,/^  render_homebrew_formula:/p' "$release_workflow")
-printf '%s\n' "$publish_container" | grep -F 'environment: release' >/dev/null
-printf '%s\n' "$publish_container" | grep -F 'registry: docker.io' >/dev/null
-printf '%s\n' "$publish_container" | grep -F 'username: flanchanxwo' >/dev/null
-printf '%s\n' "$publish_container" | grep -F 'password: ${{ secrets.DOCKER_HUB_TOKEN }}' >/dev/null
+if grep -F 'publish_container:' "$release_workflow" >/dev/null; then
+	echo 'container publication must share the single protected publish job' >&2
+	exit 1
+fi
+publish_job=$(sed -n '/^  publish:$/,/^  build_container:/p' "$release_workflow")
+test "$(printf '%s\n' "$publish_job" | grep -Fc 'environment: release')" -eq 1
+printf '%s\n' "$publish_job" | grep -F 'packages: write' >/dev/null
+printf '%s\n' "$publish_job" | grep -F 'verified-container-linux-amd64' >/dev/null
+printf '%s\n' "$publish_job" | grep -F 'verified-container-linux-arm64' >/dev/null
+printf '%s\n' "$publish_job" | grep -F 'registry: docker.io' >/dev/null
+printf '%s\n' "$publish_job" | grep -F 'username: flanchanxwo' >/dev/null
+printf '%s\n' "$publish_job" | grep -F 'password: ${{ secrets.DOCKER_HUB_TOKEN }}' >/dev/null
+printf '%s\n' "$publish_job" | grep -F 'if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then' >/dev/null
+printf '%s\n' "$publish_job" | grep -F 'test "$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '\''.isDraft'\'')" = true' >/dev/null
 grep -F 'ghcr.io/flanchanxwo/javdb-cli' "$release_workflow" >/dev/null
 grep -F 'docker manifest create "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}"' "$release_workflow" >/dev/null
 grep -F 'docker manifest create "ghcr.io/flanchanxwo/javdb-cli:latest"' "$release_workflow" >/dev/null
-printf '%s\n' "$publish_container" | grep -F 'docker push "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-${goarch}"' >/dev/null
-printf '%s\n' "$publish_container" | grep -F 'docker manifest create "flanchanxwo/javdb-cli:${RELEASE_TAG}"' >/dev/null
-printf '%s\n' "$publish_container" | grep -F 'docker manifest push "flanchanxwo/javdb-cli:${RELEASE_TAG}"' >/dev/null
-printf '%s\n' "$publish_container" | grep -F 'docker manifest create "flanchanxwo/javdb-cli:latest"' >/dev/null
-printf '%s\n' "$publish_container" | grep -F 'docker manifest push "flanchanxwo/javdb-cli:latest"' >/dev/null
-latest_promotion=$(sed -n '/^      - name: Promote latest only for the newest stable tag$/,/^  render_homebrew_formula:/p' "$release_workflow")
+printf '%s\n' "$publish_job" | grep -F 'docker push "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-${goarch}"' >/dev/null
+printf '%s\n' "$publish_job" | grep -F 'docker manifest create "flanchanxwo/javdb-cli:${RELEASE_TAG}"' >/dev/null
+printf '%s\n' "$publish_job" | grep -F 'docker manifest push "flanchanxwo/javdb-cli:${RELEASE_TAG}"' >/dev/null
+printf '%s\n' "$publish_job" | grep -F 'docker manifest create "flanchanxwo/javdb-cli:latest"' >/dev/null
+printf '%s\n' "$publish_job" | grep -F 'docker manifest push "flanchanxwo/javdb-cli:latest"' >/dev/null
+printf '%s\n' "$publish_job" | grep -F 'docker logout docker.io' >/dev/null
+printf '%s\n' "$publish_job" | grep -F 'docker manifest inspect "docker.io/flanchanxwo/javdb-cli:${RELEASE_TAG}"' >/dev/null
+container_publish_line=$(printf '%s\n' "$publish_job" | grep -nF 'docker manifest push "flanchanxwo/javdb-cli:${RELEASE_TAG}"' | cut -d: -f1)
+release_create_line=$(printf '%s\n' "$publish_job" | grep -nF 'gh release create "$RELEASE_TAG"' | cut -d: -f1)
+release_public_line=$(printf '%s\n' "$publish_job" | grep -nF 'gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false' | cut -d: -f1)
+test "$release_create_line" -lt "$container_publish_line"
+test "$container_publish_line" -lt "$release_public_line"
+latest_promotion=$(printf '%s\n' "$publish_job" | sed -n '/^      - name: Promote latest only for the newest stable tag$/,$p')
 printf '%s\n' "$latest_promotion" | grep -F "if [ \"\$RELEASE_TAG\" = \"\$latest_stable_tag\" ]; then" >/dev/null
 if printf '%s\n' "$latest_promotion" | grep -F "test \"\$RELEASE_TAG\" = \"\$latest_stable_tag\"" >/dev/null; then
 	echo 'latest promotion guard must skip older stable tags without failing the job' >&2

--- a/scripts/test-workflows.sh
+++ b/scripts/test-workflows.sh
@@ -100,9 +100,19 @@ grep -F 'publish_container:' "$release_workflow" >/dev/null
 grep -F 'needs: [build_container, publish]' "$release_workflow" >/dev/null
 grep -F 'packages: write' "$release_workflow" >/dev/null
 grep -F 'verified-container-${{ matrix.artifact }}' "$release_workflow" >/dev/null
+publish_container=$(sed -n '/^  publish_container:$/,/^  render_homebrew_formula:/p' "$release_workflow")
+printf '%s\n' "$publish_container" | grep -F 'environment: release' >/dev/null
+printf '%s\n' "$publish_container" | grep -F 'registry: docker.io' >/dev/null
+printf '%s\n' "$publish_container" | grep -F 'username: flanchanxwo' >/dev/null
+printf '%s\n' "$publish_container" | grep -F 'password: ${{ secrets.DOCKER_HUB_TOKEN }}' >/dev/null
 grep -F 'ghcr.io/flanchanxwo/javdb-cli' "$release_workflow" >/dev/null
 grep -F 'docker manifest create "ghcr.io/flanchanxwo/javdb-cli:${RELEASE_TAG}"' "$release_workflow" >/dev/null
 grep -F 'docker manifest create "ghcr.io/flanchanxwo/javdb-cli:latest"' "$release_workflow" >/dev/null
+printf '%s\n' "$publish_container" | grep -F 'docker push "flanchanxwo/javdb-cli:${RELEASE_TAG}-linux-${goarch}"' >/dev/null
+printf '%s\n' "$publish_container" | grep -F 'docker manifest create "flanchanxwo/javdb-cli:${RELEASE_TAG}"' >/dev/null
+printf '%s\n' "$publish_container" | grep -F 'docker manifest push "flanchanxwo/javdb-cli:${RELEASE_TAG}"' >/dev/null
+printf '%s\n' "$publish_container" | grep -F 'docker manifest create "flanchanxwo/javdb-cli:latest"' >/dev/null
+printf '%s\n' "$publish_container" | grep -F 'docker manifest push "flanchanxwo/javdb-cli:latest"' >/dev/null
 latest_promotion=$(sed -n '/^      - name: Promote latest only for the newest stable tag$/,/^  render_homebrew_formula:/p' "$release_workflow")
 printf '%s\n' "$latest_promotion" | grep -F "if [ \"\$RELEASE_TAG\" = \"\$latest_stable_tag\" ]; then" >/dev/null
 if printf '%s\n' "$latest_promotion" | grep -F "test \"\$RELEASE_TAG\" = \"\$latest_stable_tag\"" >/dev/null; then


### PR DESCRIPTION
## 变更

在现有 GHCR 多架构发布流程上补充 Docker Hub 发布，并把最终发布动作收敛到单一受保护 job：

- `publish` 绑定一次 `release` environment approval，同时读取签名密钥与现有 `DOCKER_HUB_TOKEN`
- 从 `build_container` 下载已验证的 `linux/amd64` 与 `linux/arm64` 镜像 artifacts
- 使用 pinned `docker/login-action` 登录 GHCR 与 Docker Hub
- 向两个 registry 推送分架构镜像并发布 `vX.Y.Z` 多架构 manifest
- 仅最新 stable tag 推进两个 registry 的 `latest`；旧 stable tag 正常跳过
- 先创建并审计 draft GitHub Release；双 registry 发布及 Docker Hub 匿名可见性验证成功后才公开 Release
- failed-job rerun 可复用尚未公开的 draft，并以幂等的相同 tag push 补齐部分成功状态；不实现跨 registry rollback
- 扩展 `scripts/test-workflows.sh`，覆盖单一 environment gate、步骤顺序、Docker Hub 凭据、push、manifest、公开可见性和 rerun 契约
- 同步更新中英文 README 和维护者发布文档；不再声称历史 `v0.2.0` Docker Hub 镜像已经存在

## Docker Hub tags

从启用该发布渠道后的 stable release 开始发布：

- `flanchanxwo/javdb-cli:vX.Y.Z`
- `flanchanxwo/javdb-cli:latest`
- `flanchanxwo/javdb-cli:vX.Y.Z-linux-amd64`
- `flanchanxwo/javdb-cli:vX.Y.Z-linux-arm64`

## 发布顺序

1. `build_container` 从不可变 release tag 构建并验证镜像
2. `publish` 通过一次 `release` environment gate
3. 创建并审计 draft GitHub Release
4. 发布 GHCR 与 Docker Hub 的架构镜像和 manifests
5. 登出 Docker Hub，匿名 inspect 版本 manifest，确认 repository 为 Public
6. 将 GitHub Release 从 draft 转为公开

## 验证

- `sh scripts/test-workflows.sh`
- `go test ./...`
- `sh scripts/build.sh`
- Release workflow YAML 解析
- `actionlint -ignore SC2046 .github/workflows/release.yml`
- 提交时仓库 hooks 全部通过

## 配置

已确认 `release` environment 中存在 `DOCKER_HUB_TOKEN`。Token 值不会写入 workflow 日志、文件或 artifact；它只传给 pinned `docker/login-action`。Token 必须具有 `flanchanxwo/javdb-cli` push 权限，repository 必须允许匿名读取。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - Docker 镜像现同时发布至 GitHub Container Registry 和 Docker Hub。
  - 支持 Linux amd64 与 arm64 多架构镜像，并提供版本、架构专属及 `latest` 标签。
  - Docker Hub 从启用后的稳定版本开始提供镜像。

- **文档**
  - 更新中英文 README 及维护者文档，补充双仓库镜像地址、标签规则与发布流程说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->