### PR TITLE
docs(release): prepare v0.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ flags with `javdb <command> --help`.
 
 Agents using ClawHub can install the published [`javdb-cli` Skill](https://clawhub.ai/flanchanxwo/skills/javdb-cli)
 with `clawhub install javdb-cli`; pin the installed skill to the matching
-published release version, currently `0.7.2`, rather than following an
+published release version, currently `0.7.3`, rather than following an
 unversioned `latest` tag.
 
 ## Authentication and credential safety

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -211,7 +211,7 @@ func main() {
 
 使用 ClawHub 的 Agent 可以通过 `clawhub install javdb-cli` 安装已发布的
 [`javdb-cli` Skill](https://clawhub.ai/flanchanxwo/skills/javdb-cli)；请将已安装的 skill 固定到对应的
-published release 版本（当前为 `0.7.2`），不要跟随无版本的 `latest` tag。
+published release 版本（当前为 `0.7.3`），不要跟随无版本的 `latest` tag。
 
 ## 认证与凭据安全
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@ grouped by user outcome and carry inline PR or historical direct-commit sources;
 | Version | Date | Release notes |
 | --- | --- | --- |
 | Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
+| [v0.7.3](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.2...v0.7.3) | 2026-09-08 | [English](v0.7.3/en.md) · [简体中文](v0.7.3/zh-CN.md) |
 | [v0.7.2](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.1...v0.7.2) | 2026-08-18 | [English](v0.7.2/en.md) · [简体中文](v0.7.2/zh-CN.md) |
 | [v0.7.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.0...v0.7.1) | 2026-08-14 | [English](v0.7.1/en.md) · [简体中文](v0.7.1/zh-CN.md) |
 | [v0.7.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.6.1...v0.7.0) | 2026-08-14 | [English](v0.7.0/en.md) · [简体中文](v0.7.0/zh-CN.md) |

--- a/changelog/README.zh-CN.md
+++ b/changelog/README.zh-CN.md
@@ -5,6 +5,7 @@
 | 版本 | 日期 | 发布说明 |
 | --- | --- | --- |
 | Unreleased | — | [English](unreleased/en.md) · [简体中文](unreleased/zh-CN.md) |
+| [v0.7.3](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.2...v0.7.3) | 2026-09-08 | [English](v0.7.3/en.md) · [简体中文](v0.7.3/zh-CN.md) |
 | [v0.7.2](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.1...v0.7.2) | 2026-08-18 | [English](v0.7.2/en.md) · [简体中文](v0.7.2/zh-CN.md) |
 | [v0.7.1](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.0...v0.7.1) | 2026-08-14 | [English](v0.7.1/en.md) · [简体中文](v0.7.1/zh-CN.md) |
 | [v0.7.0](https://github.com/FlanChanXwO/javdb-cli/compare/v0.6.1...v0.7.0) | 2026-08-14 | [English](v0.7.0/en.md) · [简体中文](v0.7.0/zh-CN.md) |

--- a/changelog/v0.7.3/en.md
+++ b/changelog/v0.7.3/en.md
@@ -1,0 +1,12 @@
+# v0.7.3 — 2026-09-08
+
+## Added
+
+- Publish verified Linux multi-architecture container images to GHCR and Docker Hub for stable releases, covering `linux/amd64` and `linux/arm64` with exact-version, per-architecture, and `latest` tags; Docker Hub publication starts with this release. ([#39](https://github.com/FlanChanXwO/javdb-cli/pull/39), [#40](https://github.com/FlanChanXwO/javdb-cli/pull/40))
+
+## Changed
+
+- Rebuild and smoke-validate container images from immutable release tags, use one protected publish job for both registries and the GitHub Release, and verify Docker Hub visibility before making the Release public. ([#39](https://github.com/FlanChanXwO/javdb-cli/pull/39), [#40](https://github.com/FlanChanXwO/javdb-cli/pull/40))
+- Replace the pull request template with bilingual change, verification, checklist, and credential-safety guidance. ([#36](https://github.com/FlanChanXwO/javdb-cli/pull/36))
+
+**Full Changelog**: [v0.7.2...v0.7.3](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.2...v0.7.3)

--- a/changelog/v0.7.3/zh-CN.md
+++ b/changelog/v0.7.3/zh-CN.md
@@ -1,0 +1,12 @@
+# v0.7.3 — 2026-09-08
+
+## 新增
+
+- 为 stable release 向 GHCR 与 Docker Hub 发布经过验证的 Linux 多架构容器镜像，覆盖 `linux/amd64` 与 `linux/arm64`，并提供精确版本、分架构和 `latest` tag；Docker Hub 从本版本开始发布。 ([#39](https://github.com/FlanChanXwO/javdb-cli/pull/39), [#40](https://github.com/FlanChanXwO/javdb-cli/pull/40))
+
+## 变更
+
+- 从不可变 release tag 重建并执行容器冒烟验证；通过一个受保护的 publish job 同时管理两个 registry 与 GitHub Release，并在公开 Release 前验证 Docker Hub 的可见性。 ([#39](https://github.com/FlanChanXwO/javdb-cli/pull/39), [#40](https://github.com/FlanChanXwO/javdb-cli/pull/40))
+- 用双语 PR 模板替换旧模板，补充变更说明、验证步骤、检查清单和凭据安全要求。 ([#36](https://github.com/FlanChanXwO/javdb-cli/pull/36))
+
+**完整变更**：[v0.7.2...v0.7.3](https://github.com/FlanChanXwO/javdb-cli/compare/v0.7.2...v0.7.3)

--- a/skills/javdb-cli/SKILL.md
+++ b/skills/javdb-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 slug: javdb-cli
-version: 0.7.2
+version: 0.7.3
 displayName: JavDB CLI
 summary: Safely operate JavDB through the javdb-cli binary for discovery, authenticated lists, and explicit state changes.
 license: MIT


### PR DESCRIPTION
## Summary
- prepare bilingual changelog for v0.7.3
- update changelog indexes and the javdb-cli skill version to 0.7.3
- align README ClawHub version references
- release scope covers merged PRs #36, #39, and #40 since v0.7.2; open PR #37 is intentionally excluded and remains open

## Verification
- `sh scripts/test-releasenotes.sh`
- `go run ./scripts/releasenotes validate --version 0.7.3 --previous v0.7.2 --dir changelog/v0.7.3`
- `sh scripts/test-workflows.sh`
- `sh scripts/test-clawhub-publish-workflow.sh`
- `go test ./...`
- `sh scripts/build.sh`
- `python3 -m pre_commit run --all-files`
- `git diff --check`

## Sourcery 总结

准备 v0.7.3 版本的发布文档和版本元数据，包括新的容器发布工作流和贡献指南。

新功能：
- 添加双语 v0.7.3 发布说明，涵盖已验证的多架构容器发布到 GHCR 和 Docker Hub。

增强功能：
- 记录 v0.7.3 版本发布，并更新 ClawHub 技能元数据和 README 中的版本引用。
- 引入双语拉取请求指南，涵盖变更描述、验证、检查清单和凭据安全。

部署：
- 作为发布流程的一部分，在 GHCR 和 Docker Hub 上发布并验证稳定版 Linux 多架构容器镜像。

文档：
- 添加 v0.7.3 英文和简体中文变更日志，并更新变更日志索引。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prepare the v0.7.3 release documentation and version metadata, including the new container publishing workflow and contribution guidance.

New Features:
- Add bilingual v0.7.3 release notes covering verified multi-architecture container publishing to GHCR and Docker Hub.

Enhancements:
- Document the v0.7.3 release and update the ClawHub skill metadata and README version references.
- Introduce bilingual pull request guidance covering change descriptions, verification, checklists, and credential safety.

Deployment:
- Publish and validate stable Linux multi-architecture container images across GHCR and Docker Hub as part of the release process.

Documentation:
- Add v0.7.3 English and Simplified Chinese changelogs and update changelog indexes.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
  - 更新 ClawHub Skill 安装说明及 Skill 版本号至 v0.7.3。
  - 新增 v0.7.3 中英文发布记录及版本索引。

- **新特性**
  - 提供经过验证的 Linux 多架构容器镜像，支持 amd64 和 arm64。
  - 镜像发布至 GHCR 与 Docker Hub，并提供版本、架构及 latest 标签。

- **发布流程**
  - 发布前增加镜像重建、冒烟验证及 Docker Hub 可见性检查。
  - 更新为双语 PR 模板，补充变更说明、验证清单与凭据安全指引。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->