### PR TITLE
docs: add official JavDB app links

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,3 +288,8 @@ large or compatibility-sensitive changes first.
 ## License
 
 [MIT](LICENSE) © FlanChanXwO
+
+## Official JavDB App
+
+- **Website:** [javdb.com](https://javdb.com)
+- **App Download:** [GitHub Releases](https://github.com/bdvajstudio/javdb/releases)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -257,3 +257,8 @@ javdb config set auto_relogin true
 ## 许可证
 
 [MIT](LICENSE) © FlanChanXwO
+
+## JavDB 官方 App
+
+- **官方网站：** [javdb.com](https://javdb.com)
+- **App 下载：** [GitHub Releases](https://github.com/bdvajstudio/javdb/releases)


### PR DESCRIPTION
## Summary

- add a dedicated `Official JavDB App` section at the bottom of the English README
- add the matching `JavDB 官方 App` section to the Simplified Chinese README
- link the JavDB website and use the official `bdvajstudio/javdb` GitHub Releases page as the single App download entry

## Scope

Documentation only. No code, build, release, or configuration changes.

## Verification

The official `bdvajstudio/javdb` repository identifies `https://javdb.com` as the official site and lists its GitHub Releases page as a download source. The branch diff contains only 5 added lines in each README and no deletions.

## Sourcery 摘要

文档：
- 添加英文和简体中文 README 部分，链接至官方 JavDB 网站和应用下载版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add English and Simplified Chinese README sections linking to the official JavDB website and app download releases.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 在英文和简体中文 README 中新增官方应用章节。
  * 提供官方网站及官方应用下载地址。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->